### PR TITLE
Update firebase ios pods to latest versions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -121,13 +121,13 @@
 				<source url="https://github.com/CocoaPods/Specs.git"/>
 			</config>
 			<pods use-frameworks="true">
-				<pod name="Firebase/Core" spec="6.3.0"/>
-				<pod name="Firebase/Auth" spec="6.3.0"/>
-				<pod name="Firebase/Messaging" spec="6.3.0"/>
-				<pod name="Firebase/Performance" spec="6.3.0"/>
-				<pod name="Firebase/RemoteConfig" spec="6.3.0"/>
-				<pod name="Fabric" spec="1.9.0"/>
-				<pod name="Crashlytics" spec="3.12.0"/>
+				<pod name="Firebase/Core" spec="6.9.0"/>
+				<pod name="Firebase/Auth" spec="6.9.0"/>
+				<pod name="Firebase/Messaging" spec="6.9.0"/>
+				<pod name="Firebase/Performance" spec="6.9.0"/>
+				<pod name="Firebase/RemoteConfig" spec="6.9.0"/>
+				<pod name="Fabric" spec="1.10.2"/>
+				<pod name="Crashlytics" spec="3.14.0"/>
 			</pods>
 		</podspec>
 


### PR DESCRIPTION
This fixes a bunch of problems with iOS13, like [this one](https://github.com/firebase/firebase-ios-sdk/issues/3365). Especially some problems with calling UIKit methods on a background thread (which can lead to crashes) were fixed since version `6.3.0`.

The changelog for the different iOS releases can be found [here](https://firebase.google.com/support/release-notes/ios).

Personally I only use Firebase/Analytics in my projects so I only tested this functionality, no problems so far, warnings, freezes (in dev mode), crashes on iOS13 are gone.

For upgrading it may be required to update the cocoapods repo before adding the plugin with the new versions: run `pod repo update` in your terminal to do so.