### PR TITLE
feat(android): add `description` option for channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,6 +1120,9 @@ Calling on Android 7 or below or another platform will have no effect.
 var channel  = {
     // channel ID - must be unique per app package
     id: "my_channel_id",
+
+    // Channel description. Default: empty string
+    description: "Channel description",
     
     // Channel name. Default: empty string
     name: "Channel name",
@@ -1209,6 +1212,7 @@ Calling on Android 7 or below or another platform will have no effect.
 var options = {
   id: "my_default_channel",
   name: "My Default Name",
+  description: "My Default Description",
   sound: "ringtone",
   vibration: [500, 200, 500],
   light: true,
@@ -1234,6 +1238,7 @@ The default channel is initialised at app startup with the following default set
 {
     id: "fcm_default_channel",
     name: "Default",
+    description: "",
     sound: "default",
     vibration: true,
     light: true,

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1030,6 +1030,11 @@ public class FirebasePlugin extends CordovaPlugin {
                     name,
                     importance);
 
+            // Description
+            String description = options.optString("description", "");
+            Log.d(TAG, "Channel "+id+" - description="+description);
+            channel.setDescription(description);
+
             // Light
             boolean light = options.optBoolean("light", true);
             Log.d(TAG, "Channel "+id+" - light="+light);


### PR DESCRIPTION
I notice that android custom channel supports additional description. 😉 

* added [`description`](https://developer.android.com/reference/android/app/NotificationChannel.html?hl=RU#setDescription(java.lang.String)) option on channel creating 
* updated readme

![image](https://user-images.githubusercontent.com/3195714/66079802-7219cc00-e56d-11e9-851e-41536a84ebd9.png)
