### PR TITLE
Update CocoaPods spec url to new CDN

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -118,7 +118,7 @@
 
 		<podspec>
 			<config>
-				<source url="https://github.com/CocoaPods/Specs.git"/>
+				<source url="https://cdn.cocoapods.org/"/>
 			</config>
 			<pods use-frameworks="true">
 				<pod name="Firebase/Core" spec="6.9.0"/>


### PR DESCRIPTION
While attempting to run `pod install`, the default spec repo is killing my build times due to its size. CocoaPods [new CDN](http://blog.cocoapods.org/CocoaPods-1.8.0-beta/) to fix this issue is being overridden by the plugin.

I have confirmed that this change significantly reduces `pod install` time, and still allows proper installation.