### PR TITLE
Updated snippet code default android icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ The default notification icon images **must** be named `notification_icon.png`.
 You then need to add a `<config-file>` block to the `config.xml` which will instruct Firebase to use your icon as the default for notifications:
 
     <platform name="android">
-        <config-file target="AndroidManifest.xml" parent="application">
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon" />
         </config-file>
     </platform>


### PR DESCRIPTION
Updated example snippet code to set default android icon in config.xml with the `<config-file>` block. Parent tag must contain "**/manifest/application**" value to avoid android Manifest overwrite error from cordova.

This resolve [this issue](https://github.com/dpa99c/cordova-plugin-firebasex/issues/85) reported as cordova bug [here](https://github.com/apache/cordova-android/issues/809) and it's not necessary use cordova-custom-config plugin