### PR TITLE
Remove check for presence of platform in config.xml

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -50,16 +50,14 @@ var parsePluginVariables = function(){
   const deferred = Q.defer();
   var parseConfigXml = function () {
     parser.parseString(config, function (err, data) {
-      if (data.widget.platform) {
-        (data.widget.plugin || []).forEach(function (plugin) {
-          (plugin.variable || []).forEach(function (variable) {
-            if((plugin.$.name === PLUGIN_ID || plugin.$.id === PLUGIN_ID) && variable.$.name && variable.$.value){
-              pluginVariables[variable.$.name] = variable.$.value;
-            }
-          });
+      (data.widget.plugin || []).forEach(function (plugin) {
+        (plugin.variable || []).forEach(function (variable) {
+          if((plugin.$.name === PLUGIN_ID || plugin.$.id === PLUGIN_ID) && variable.$.name && variable.$.value){
+            pluginVariables[variable.$.name] = variable.$.value;
+          }
         });
-        deferred.resolve();
-      }
+      });
+      deferred.resolve();
     });
     return deferred.promise;
   };


### PR DESCRIPTION
I ran into another form of issue https://github.com/dpa99c/cordova-plugin-firebasex/issues/101 today. The `config.xml` for my Cordova app didn't have any platform elements yet, due to which a promise in the `after_prepare.js` script didn't resolve.

As far as I can see the check for the presence of platform elements is superfluous, so I removed it.