### PR TITLE
[#165] Pass context on static methods

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1189,7 +1189,7 @@ public class FirebasePlugin extends CordovaPlugin {
     public static boolean channelExists(String channelId, Context context){
         boolean exists = false;
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-            List<NotificationChannel> notificationChannels = FirebasePlugin.listChannels(Context context);
+            List<NotificationChannel> notificationChannels = FirebasePlugin.listChannels(context);
             if(notificationChannels != null){
                 for (NotificationChannel notificationChannel : notificationChannels) {
                     if(notificationChannel.getId() == channelId){

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1013,7 +1013,7 @@ public class FirebasePlugin extends CordovaPlugin {
             String id = options.getString("id");
             Log.i(TAG, "Creating channel id="+id);
 
-            if(channelExists(id)){
+            if(channelExists(id, cordovaActivity)){
                 deleteChannel(id);
             }
 
@@ -1158,7 +1158,7 @@ public class FirebasePlugin extends CordovaPlugin {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 try {
-                    List<NotificationChannel> notificationChannels = listChannels();
+                    List<NotificationChannel> notificationChannels = listChannels(cordovaActivity);
                     JSONArray channels = new JSONArray();
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                         for (NotificationChannel notificationChannel : notificationChannels) {
@@ -1176,20 +1176,20 @@ public class FirebasePlugin extends CordovaPlugin {
         });
     }
 
-    public static List<NotificationChannel> listChannels(){
+    public static List<NotificationChannel> listChannels(Context context){
         List<NotificationChannel> notificationChannels = null;
         // only call on Android O and above
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationManager nm = (NotificationManager) cordovaActivity.getSystemService(Context.NOTIFICATION_SERVICE);
+            NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationChannels = nm.getNotificationChannels();
         }
         return notificationChannels;
     }
 
-    public static boolean channelExists(String channelId){
+    public static boolean channelExists(String channelId, Context context){
         boolean exists = false;
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-            List<NotificationChannel> notificationChannels = FirebasePlugin.listChannels();
+            List<NotificationChannel> notificationChannels = FirebasePlugin.listChannels(Context context);
             if(notificationChannels != null){
                 for (NotificationChannel notificationChannel : notificationChannels) {
                     if(notificationChannel.getId() == channelId){

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -194,7 +194,7 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             PendingIntent pendingIntent = PendingIntent.getBroadcast(this, id.hashCode(), intent, PendingIntent.FLAG_UPDATE_CURRENT);
 
             // Channel
-            if(channelId == null || FirebasePlugin.channelExists(channelId)){
+            if(channelId == null || FirebasePlugin.channelExists(channelId, this.getApplicationContext())){
                 channelId = FirebasePlugin.defaultChannelId;
             }
             if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){


### PR DESCRIPTION
When the app is not running, the plugin is not initialized, so cordovaActivity is not available.

This PR is a starting point for fixing this