### PR TITLE
Fixed '(plugin.variable || []).forEach is not a function'

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -46,7 +46,11 @@ var PLATFORM = {
 var parsePluginVariables = function(){
     var config = Utilities.parseConfigXml();
     (config.widget.plugin || []).forEach(function(plugin){
-        (plugin.variable || []).forEach(function(variable){
+        var pluginVar = plugin.variable || [];
+        if(!('forEach' in pluginVar)){
+            pluginVar = [pluginVar];
+        }
+        pluginVar.forEach(function(variable){
             if((plugin._attributes.name === PLUGIN_ID || plugin._attributes.id === PLUGIN_ID) && variable._attributes.name && variable._attributes.value){
                 pluginVariables[variable._attributes.name] = variable._attributes.value;
             }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [X] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

This commit fixes '(plugin.variable || []).forEach is not a function' when using this plugin together with some others (e.g. calendar). The problem is triggered when plugin.variable is not an array but an object as follows:
{ _attributes:
   { name: 'CALENDAR_USAGE_DESCRIPTION',
     value: 'This app can sync your calendar.' } }

With this fix, it will work either way.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information