### PR TITLE
Fix .forEach is not a function

### DIFF
--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -45,8 +45,8 @@ var PLATFORM = {
 
 var parsePluginVariables = function(){
     var config = Utilities.parseConfigXml();
-    (config.widget.plugin || []).forEach(function(plugin){
-        (plugin.variable || []).forEach(function(variable){
+    (config.widget.plugin ? [].concat(config.widget.plugin) : []).forEach(function(plugin){
+        (plugin.variable ? [].concat(plugin.variable) : []).forEach(function(variable){
             if((plugin._attributes.name === PLUGIN_ID || plugin._attributes.id === PLUGIN_ID) && variable._attributes.name && variable._attributes.value){
                 pluginVariables[variable._attributes.name] = variable._attributes.value;
             }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
As described in #217 the after_prepare script hangs with error `.forEach is not a function`. This happens either if there is only one plugin configuration in the config.xml or if a plugin configuration only has one variable. This is due to `config.widget.plugin` or `plugin.variable` not being arrays in this cases. This PR makes sure that both always are arrays.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
Tested with different config.xml scenarios.

## What testing has been done on existing functionality?
Tested with different config.xml scenarios.

## Other information

The open PR #213 (which I discovered just now before submitting mine) does not fix both cases.