### PR TITLE
Fixed retrieving Xcode project path

### DIFF
--- a/scripts/ios/after_plugin_install.js
+++ b/scripts/ios/after_plugin_install.js
@@ -4,8 +4,7 @@ module.exports = function(context) {
 
     // Add a build phase which runs a shell script that executes the Crashlytics
     // run command line tool which uploads the debug symbols at build time.
-    helper.getXcodeProjectPath(function(xcodeProjectPath){
-        helper.removeShellScriptBuildPhase(context, xcodeProjectPath);
-        helper.addShellScriptBuildPhase(context, xcodeProjectPath);
-    });
+    var xcodeProjectPath = helper.getXcodeProjectPath();
+    helper.removeShellScriptBuildPhase(context, xcodeProjectPath);
+    helper.addShellScriptBuildPhase(context, xcodeProjectPath);
 };


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [X] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
When installing plugin for iOS, the plugin doesn't add custom run script required for Crashlytics in Xcode generated project. This PR fixes that retrieving correctly the Xcode project path.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No
