### PR TITLE
[Android] Add check google-services plugin does not exist

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -21,8 +21,17 @@ repositories {
 }
 
 cdvPluginPostBuildExtras.add({
+    rootProject.subprojects {
+        if (name == "app") {
+            if (!plugins.hasPlugin('com.google.gms.google-services')) {
+                apply {
+                    plugin com.google.gms.googleservices.GoogleServicesPlugin
+                }
+            }
+        }
+    }
     // Use class instead of id (string) to be able to apply plugin from non-root gradle file
-    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+
     apply plugin: com.crashlytics.tools.gradle.CrashlyticsPlugin
 
     // Enable Crashlytics NDK reporting


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added

## What is the purpose of this PR?
To fix an error "Cannot add extension with name 'googleServices', as there is an extension already registered with that name".

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No