### PR TITLE
Added missing Google Tag Manager Pod for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -129,6 +129,7 @@
 				<pod name="Fabric" spec="1.10.2"/>
 				<pod name="Crashlytics" spec="3.14.0"/>
 				<pod name="GoogleSignIn" spec="5.0.2"/>
+				<pod name="GoogleTagManager" spec="7.1.2"/>
 			</pods>
 		</podspec>
 


### PR DESCRIPTION
## PR Type
Added missing GoogleTagManager Cocoapods dependency (for iOS).

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist

- [X] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
Expected behaviour was having GTM support for iOS out-of-the-box.

Current PR fixes that adding missing Cocoapods dependency to plugin.xml (seamless with Android configuration).

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## What testing has been done on the changes in the PR?

Creating and running iOS App with support for GTM / Google Analytics.
