### PR TITLE
Prevent reconfiguration causing exception

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -57,26 +57,26 @@ static bool shouldEstablishDirectChannel = false;
     @try{
         instance = self;
         
-        // get GoogleService-Info.plist file path
-        NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
-        
-        // if file is successfully found, use it
-        if(filePath){
-            [FirebasePlugin.firebasePlugin _logMessage:@"GoogleService-Info.plist found, setup: [FIRApp configureWithOptions]"];
-            // create firebase configure options passing .plist as content
-            FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
+        if(![FIRApp defaultApp]) {
+            // get GoogleService-Info.plist file path
+            NSString *filePath = [[NSBundle mainBundle] pathForResource:@"GoogleService-Info" ofType:@"plist"];
             
-            // configure FIRApp with options
-            [FIRApp configureWithOptions:options];
-            if([FirebasePlugin.firebasePlugin _shouldEnableCrashlytics]){
-                [Fabric with:@[[Crashlytics class]]];
+            // if file is successfully found, use it
+            if(filePath){
+                [FirebasePlugin.firebasePlugin _logMessage:@"GoogleService-Info.plist found, setup: [FIRApp configureWithOptions]"];
+                // create firebase configure options passing .plist as content
+                FIROptions *options = [[FIROptions alloc] initWithContentsOfFile:filePath];
+
+                // configure FIRApp with options
+                [FIRApp configureWithOptions:options];
+                if([FirebasePlugin.firebasePlugin _shouldEnableCrashlytics]){
+                    [Fabric with:@[[Crashlytics class]]];
+                }
+            }else{
+                // no .plist found, try default App
+                [FirebasePlugin.firebasePlugin _logError:@"GoogleService-Info.plist NOT FOUND, setup: [FIRApp defaultApp]"];
+                [FIRApp configure];
             }
-        }
-        
-        // no .plist found, try default App
-        if (![FIRApp defaultApp] && !filePath) {
-            [FirebasePlugin.firebasePlugin _logError:@"GoogleService-Info.plist NOT FOUND, setup: [FIRApp defaultApp]"];
-            [FIRApp configure];
         }
         
         shouldEstablishDirectChannel = [[[NSBundle mainBundle] objectForInfoDictionaryKey:@"shouldEstablishDirectChannel"] boolValue];


### PR DESCRIPTION
We ran into a problem with a configuration using the firebasex and firebase-analytics plugins together. The latter was performing `[FIRApp configure]` during the `[self application:application...` super call at the top of this function, which caused an exception when FIRApp was configured again by this plugin. This exception bypassed the remainder of the code block and prevented our app from receiving push notification data when the terminated (not just backgrounded) iOS app was opened by tapping a notification.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

Reconfiguration of FIRApp causes an exception in `appWasConfiguredTwice`. Another plugin (firebase-analytics) was configuring FIRapp already, so this simply makes configuration conditional on `![FIRApp defaultApp]`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

Without this change, the exception is raised and data from a tapped push notification received when the app is terminated does not reach our code. With the change, all notifications work as expected.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

Our app works as expected now.

## Other information

Sorry, I forgot to make a branch and just made the change directly in the master of my fork. Let me know if that's a problem and I can resubmit. It's really a one-line logic change with some whitespace implications. Thanks for all your great work!