### PR TITLE
(iOS/Android): avoid collection state getting out of sync, remove restriction to override plist defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "plist": "^3.0.1",
-    "xcode": "^2.0.0",
+    "xcode": "^3.0.1",
     "xml-js": "^1.6.11"
   }
 }

--- a/scripts/ios/helper.js
+++ b/scripts/ios/helper.js
@@ -139,20 +139,27 @@ module.exports = {
     ensureRunpathSearchPath: function(context, xcodeProjectPath){
 
         function addRunpathSearchBuildProperty(proj, build) {
-            const LD_RUNPATH_SEARCH_PATHS = proj.getBuildProperty("LD_RUNPATH_SEARCH_PATHS", build);
-            if (!LD_RUNPATH_SEARCH_PATHS) {
-                proj.addBuildProperty("LD_RUNPATH_SEARCH_PATHS", "\"$(inherited) @executable_path/Frameworks\"", build);
+            let LD_RUNPATH_SEARCH_PATHS = proj.getBuildProperty("LD_RUNPATH_SEARCH_PATHS", build);
+
+            if (!Array.isArray(LD_RUNPATH_SEARCH_PATHS)) {
+                LD_RUNPATH_SEARCH_PATHS = [LD_RUNPATH_SEARCH_PATHS];
             }
-            if (LD_RUNPATH_SEARCH_PATHS.indexOf("@executable_path/Frameworks") == -1) {
-                var newValue = LD_RUNPATH_SEARCH_PATHS.substr(0, LD_RUNPATH_SEARCH_PATHS.length - 1);
-                newValue += ' @executable_path/Frameworks\"';
-                proj.updateBuildProperty("LD_RUNPATH_SEARCH_PATHS", newValue, build);
-            }
-            if (LD_RUNPATH_SEARCH_PATHS.indexOf("$(inherited)") == -1) {
-                var newValue = LD_RUNPATH_SEARCH_PATHS.substr(0, LD_RUNPATH_SEARCH_PATHS.length - 1);
-                newValue += ' $(inherited)\"';
-                proj.updateBuildProperty("LD_RUNPATH_SEARCH_PATHS", newValue, build);
-            }
+
+            LD_RUNPATH_SEARCH_PATHS.forEach(LD_RUNPATH_SEARCH_PATH => {
+                if (!LD_RUNPATH_SEARCH_PATH) {
+                    proj.addBuildProperty("LD_RUNPATH_SEARCH_PATHS", "\"$(inherited) @executable_path/Frameworks\"", build);
+                }
+                if (LD_RUNPATH_SEARCH_PATH.indexOf("@executable_path/Frameworks") == -1) {
+                    var newValue = LD_RUNPATH_SEARCH_PATH.substr(0, LD_RUNPATH_SEARCH_PATH.length - 1);
+                    newValue += ' @executable_path/Frameworks\"';
+                    proj.updateBuildProperty("LD_RUNPATH_SEARCH_PATHS", newValue, build);
+                }
+                if (LD_RUNPATH_SEARCH_PATH.indexOf("$(inherited)") == -1) {
+                    var newValue = LD_RUNPATH_SEARCH_PATH.substr(0, LD_RUNPATH_SEARCH_PATH.length - 1);
+                    newValue += ' $(inherited)\"';
+                    proj.updateBuildProperty("LD_RUNPATH_SEARCH_PATHS", newValue, build);
+                }
+            });
         }
 
         // Read and parse the XCode project (.pxbproj) from disk.

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -958,10 +958,6 @@ static NSDictionary* googlePlist;
             CDVPluginResult* pluginResult;
             if([self getGooglePlistFlagWithDefaultValue:FIREBASE_ANALYTICS_COLLECTION_ENABLED defaultValue:YES]){
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Analytics data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-            }else if(enabled && [self getPreferenceFlag:FIREBASE_ANALYTICS_COLLECTION_ENABLED]){
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Analytics data collection is already set to enabled"];
-            }else if(!enabled && ![self getPreferenceFlag:FIREBASE_ANALYTICS_COLLECTION_ENABLED]){
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Analytics data collection is already set to disabled"];
             }else{
                 [FIRAnalytics setAnalyticsCollectionEnabled:enabled];
                 [self setPreferenceFlag:FIREBASE_ANALYTICS_COLLECTION_ENABLED flag:enabled];
@@ -1058,10 +1054,6 @@ static NSDictionary* googlePlist;
              CDVPluginResult* pluginResult;
              if([self getGooglePlistFlagWithDefaultValue:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED defaultValue:YES]){
                  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Crashlytics data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-             }else if(enabled && [self getPreferenceFlag:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Crashlytics data collection is already set to enabled"];
-             }else if(!enabled && ![self getPreferenceFlag:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Crashlytics data collection is already set to disabled"];
              }else{
                  [self setPreferenceFlag:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED flag:enabled];
                  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
@@ -1288,10 +1280,6 @@ static NSDictionary* googlePlist;
              CDVPluginResult* pluginResult;
              if([self getGooglePlistFlagWithDefaultValue:FIREBASE_PERFORMANCE_COLLECTION_ENABLED defaultValue:YES]){
                  pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Performance data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-             }else if(enabled && [self getPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Performance data collection is already set to enabled"];
-             }else if(!enabled && ![self getPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Performance data collection is already set to disabled"];
              }else{
                  [[FIRPerformance sharedInstance] setDataCollectionEnabled:enabled];
                  [self setPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED flag:enabled];

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -956,13 +956,10 @@ static NSDictionary* googlePlist;
          @try {
             BOOL enabled = [[command argumentAtIndex:0] boolValue];
             CDVPluginResult* pluginResult;
-            if([self getGooglePlistFlagWithDefaultValue:FIREBASE_ANALYTICS_COLLECTION_ENABLED defaultValue:YES]){
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Analytics data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-            }else{
-                [FIRAnalytics setAnalyticsCollectionEnabled:enabled];
-                [self setPreferenceFlag:FIREBASE_ANALYTICS_COLLECTION_ENABLED flag:enabled];
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-            }
+            [FIRAnalytics setAnalyticsCollectionEnabled:enabled];
+            [self setPreferenceFlag:FIREBASE_ANALYTICS_COLLECTION_ENABLED flag:enabled];
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+             
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
          }@catch (NSException *exception) {
              [self handlePluginExceptionWithContext:exception :command];
@@ -1052,12 +1049,8 @@ static NSDictionary* googlePlist;
          @try {
              BOOL enabled = [[command argumentAtIndex:0] boolValue];
              CDVPluginResult* pluginResult;
-             if([self getGooglePlistFlagWithDefaultValue:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED defaultValue:YES]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Crashlytics data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-             }else{
-                 [self setPreferenceFlag:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED flag:enabled];
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-             }
+             [self setPreferenceFlag:FIREBASE_CRASHLYTICS_COLLECTION_ENABLED flag:enabled];
+             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
              
              [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
          }@catch (NSException *exception) {
@@ -1278,13 +1271,9 @@ static NSDictionary* googlePlist;
          @try {
              BOOL enabled = [[command argumentAtIndex:0] boolValue];
              CDVPluginResult* pluginResult;
-             if([self getGooglePlistFlagWithDefaultValue:FIREBASE_PERFORMANCE_COLLECTION_ENABLED defaultValue:YES]){
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Cannot set Performance data collection at runtime as it's hard-coded to ENABLED at build-time in the plist"];
-             }else{
-                 [[FIRPerformance sharedInstance] setDataCollectionEnabled:enabled];
-                 [self setPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED flag:enabled];
-                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-             }
+             [[FIRPerformance sharedInstance] setDataCollectionEnabled:enabled];
+             [self setPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED flag:enabled];
+             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
 
              [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
          }@catch (NSException *exception) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
Currently it is possible for the 3 collections (analytics collection, performance collection, crashlytics collection) to get into an inconsistent state. 
This is possible because when setting the flags an error is thrown if the plugins own state already matches the value the user would like to set (e.g. "Analytics data collection is already set to enabled"). However it is possible the Firebase SDK was already used before the plist config flags were introduced which could lead to the following scenario:

- In the old SDK the user has enabled the analytics collection (SDK is in state enabled, no plist config yet) ✅
- App is updated to new plugin version with all three plist flags set to true (SDK and plugin are in state enabled) ✅
- _App developer implements GDPR requirements and all three collections are now opt-in_
- App is updated and all three plist flags are set to false (SDK is in state disabled but plugin stays in state enabled) ❌
- If the user now enables one of the flags the plugin returns an error as the local plugin state indicates it is already enabled whereas in fact it is not (the SDK strictly follows the plist flags). ❌

I understand the plugins local state was added to provide information about the state, which is not exposed by the SDK itself, so it the plugins own state cannot be removed completely.

This PR removes the logic which prevents the users setting from being set directly in the SDK. This solves the above mentioned scenario (and other variations of it) and also keeps the ability to provide info about the current state. 

**Update:**
In my followup commits I also did the same changes for Android and I also removed the check which does not allow to override the plist default values if they are set to `true`. This way developers can also offer an "opt-out" scenario, where data-collection is enabled by default and can be disabled by the user on-demand.

I also checked the [firebase documentation](https://firebase.google.com/docs/analytics/configure-data-collection) and it also says that always the SDK preference takes precedence over the plist config:

> The value set by the setAnalyticsCollectionEnabled method persists across app executions and overrides the value for FIREBASE_ANALYTICS_COLLECTION_ENABLED in your app's Info.plist file.

Which is why I don't really see the reasoning behind these checks in the plugin.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
Enabling/disabling the three collections. Test different combinations of old SDK and then updating to the new SDK, changing plist flags them again enabling/disabling the flags.

## What testing has been done on existing functionality?
Tested in our in-house projects which all use the firebase plugin - no regressions so far.