### PR TITLE
(iOS) Fix escaping already escaped json

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -1640,7 +1640,8 @@ static NSDictionary* googlePlist;
 
 - (NSString*)escapeJavascriptString: (NSString*)str
 {
-    NSString* result = [str stringByReplacingOccurrencesOfString: @"\"" withString: @"\\\""];
+    NSString* result = [str stringByReplacingOccurrencesOfString: @"\\\"" withString: @"\""];
+    result = [result stringByReplacingOccurrencesOfString: @"\"" withString: @"\\\""];
     result = [result stringByReplacingOccurrencesOfString: @"\n" withString: @"\\\n"];
     return result;
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
Prevent `escapeJavascriptString` method to escape already escaped symbols
Fixes #401

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
Sending already escaped json as `data` property

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->
Tested in in-house project which uses FCM functionality of this plugin – no regressions