### PR TITLE
use FirebaseFirestore pre-compiled pod

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -137,7 +137,7 @@
 				<pod name="Firebase/Performance" spec="6.23.0"/>
 				<pod name="Firebase/RemoteConfig" spec="6.23.0"/>
 				<pod name="Firebase/InAppMessaging" spec="6.23.0"/>
-				<pod name="Firebase/Firestore" spec="6.23.0"/>
+				<pod name="Firebase/Firestore" git="https://github.com/invertase/firestore-ios-sdk-frameworks.git" tag="6.23.0"/>
 				<pod name="Firebase/Crashlytics" spec="6.23.0"/>
 				<pod name="GoogleSignIn" spec="5.0.2"/>
 				<pod name="GoogleTagManager" spec="7.1.2"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -137,7 +137,7 @@
 				<pod name="Firebase/Performance" spec="6.23.0"/>
 				<pod name="Firebase/RemoteConfig" spec="6.23.0"/>
 				<pod name="Firebase/InAppMessaging" spec="6.23.0"/>
-				<pod name="Firebase/Firestore" git="https://github.com/invertase/firestore-ios-sdk-frameworks.git" tag="6.23.0"/>
+				<pod name="FirebaseFirestore" git="https://github.com/invertase/firestore-ios-sdk-frameworks.git" tag="6.23.0"/>
 				<pod name="Firebase/Crashlytics" spec="6.23.0"/>
 				<pod name="GoogleSignIn" spec="5.0.2"/>
 				<pod name="GoogleTagManager" spec="7.1.2"/>


### PR DESCRIPTION
Use pre-compiled version of Firebase Firestore pod to reduce build times on iOS.
Significantly reduces build times, please see https://github.com/invertase/firestore-ios-sdk-frameworks for further details!

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ x] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

