### PR TITLE
Set custom locations for platform config files using plugin variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,16 @@ Check out this [firebase article](https://support.google.com/firebase/answer/701
     GoogleService-Info.plist   <--
     ...
 ```
+
+Or you can set custom location for your platform configuration files using plugin variables in your `config.xml`:
+
+```
+<plugin name="cordova-plugin-firebasex">
+    <variable name="ANDROID_KEY" value="resources/android/google-services.json" />
+    <variable name="IOS_KEY" value="resources/ios/GoogleService-Info.plist" />
+</plugin>
+```
+
 IMPORTANT: The Firebase SDK requires the configuration files to be present and valid, otherwise your app will crash on boot or Firebase features won't work.
 
 # Disable data collection on startup

--- a/scripts/after_prepare.js
+++ b/scripts/after_prepare.js
@@ -82,6 +82,10 @@ var parsePluginVariables = function(){
             }
         }
     }
+
+    // set platform key path from plugin variable
+    if (pluginVariables.ANDROID_KEY) PLATFORM.ANDROID.src = [pluginVariables.ANDROID_KEY];
+    if (pluginVariables.IOS_KEY) PLATFORM.IOS.src = [pluginVariables.IOS_KEY];
 };
 
 module.exports = function (context) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
This PR adds possibility to set custom location for `google-services.json` and `GoogleService-Info.plist` using ANDROID_KEY and IOS_KEY variables.


## Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information