### PR TITLE
[Feature] Actionable notifications: foreground, background, destructive

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -120,6 +120,8 @@
 		<source-file src="src/ios/FirebasePluginMessageReceiver.m" />
 		<header-file src="src/ios/FirebasePluginMessageReceiverManager.h" />
 		<source-file src="src/ios/FirebasePluginMessageReceiverManager.m" />
+		<header-file src="src/ios/PharmacyActionableNotifications.h" />
+		<source-file src="src/ios/PharmacyActionableNotifications.m" />
 
 		<framework src="AuthenticationServices.framework" />
 

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -2,6 +2,7 @@
 #import "FirebasePlugin.h"
 #import "Firebase.h"
 #import <objc/runtime.h>
+#import "PharmacyActionableNotifications.h"
 
 
 @import UserNotifications;
@@ -474,6 +475,9 @@ didDisconnectWithUser:(GIDGoogleUser *)user
         // Dynamic Actions
         if (response.actionIdentifier && ![response.actionIdentifier isEqual:UNNotificationDefaultActionIdentifier]) {
             [mutableUserInfo setValue:response.actionIdentifier forKey:@"action"];
+            
+            // Send post request to update reminder event
+            [[[PharmacyActionableNotifications alloc] init] updateHistoryAction:mutableUserInfo AppDelegate:self];
         }
         
         // Print full message.

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -87,7 +87,6 @@ static NSDictionary* googlePlist;
     }
 }
 
-
 // Dynamic actions from pn-actions.json
 - (void)setActionableNotifications {
     
@@ -107,9 +106,19 @@ static NSDictionary* googlePlist;
         for (NSDictionary *action in actions) {
             NSString *actionId = [action objectForKey:@"id"];
             NSString *actionTitle = [action objectForKey:@"title"];
-        
+            UNNotificationActionOptions options = UNNotificationActionOptionNone;
+            
+            id mode = [action objectForKey:@"foreground"];
+            if (mode != nil && (([mode isKindOfClass:[NSString class]] && [mode isEqualToString:@"true"]) || [mode boolValue])) {
+                options |= UNNotificationActionOptionForeground;
+            }
+            id destructive = [action objectForKey:@"destructive"];
+            if (destructive != nil && (([destructive isKindOfClass:[NSString class]] && [destructive isEqualToString:@"true"]) || [destructive boolValue])) {
+                options |= UNNotificationActionOptionDestructive;
+            }
+            
             [buttons addObject:[UNNotificationAction actionWithIdentifier:actionId
-                title:NSLocalizedString(actionTitle, nil) options:UNNotificationActionOptionNone]];
+                title:NSLocalizedString(actionTitle, nil) options:options]];
         }
         
         [categories addObject:[UNNotificationCategory categoryWithIdentifier:category

--- a/src/ios/PharmacyActionableNotifications.h
+++ b/src/ios/PharmacyActionableNotifications.h
@@ -1,0 +1,10 @@
+//
+//  PharmacyActionableNotifications.h
+//  Atlantic Pharmacy
+//
+//  Created by Roman Antonov on 13/9/20.
+//
+#import "AppDelegate.h"
+@interface PharmacyActionableNotifications: NSObject
+- (void) updateHistoryAction:(NSDictionary *) userInfo AppDelegate:(AppDelegate*) appDelegate;
+@end

--- a/src/ios/PharmacyActionableNotifications.m
+++ b/src/ios/PharmacyActionableNotifications.m
@@ -1,0 +1,80 @@
+//
+//  PharmacyActionableNotifications.m
+//  Atlantic Pharmacy
+//
+//  Created by Roman Antonov on 13/9/20.
+//
+
+#import "PharmacyActionableNotifications.h"
+#import <WebKit/WKWebView.h>
+
+@implementation PharmacyActionableNotifications
+
+- (void)updateHistoryAction:(NSDictionary *)userInfo
+                AppDelegate:(AppDelegate *) appDelegate {
+    if ([[userInfo objectForKey:@"action"] isEqualToString:@"snooze"]
+        || [[userInfo objectForKey:@"action"] isEqualToString:@"take"]
+        || [[userInfo objectForKey:@"action"] isEqualToString:@"skip"]) {
+        
+        // Get data from localStorage of wkwebview
+        [(WKWebView*) appDelegate.viewController.webView
+            evaluateJavaScript:@"JSON.stringify({device_token_key: localStorage.device_token_key, \
+                device_token: localStorage.device_token, \
+                API_URL: localStorage.API_URL, \
+                API_KEY: localStorage.API_KEY})"
+            completionHandler:^(NSString* result, NSError *error) {
+            
+            if (error == nil) {
+                if (result != nil) {
+                    NSError *jsonError;
+                    NSData *objectData = [result dataUsingEncoding:NSUTF8StringEncoding];
+                    NSDictionary *json = [NSJSONSerialization JSONObjectWithData:objectData
+                                                          options:NSJSONReadingMutableContainers
+                                                            error:&jsonError];
+                    
+                    NSString *url = [json objectForKey:@"API_URL"];
+                    url = [url stringByAppendingString:@"api/update-history-action/"];
+                    url = [url stringByAppendingString:[json objectForKey:@"API_KEY"]];
+                    
+                    NSString *params = [NSString stringWithFormat:@"device_token_key=%@&device_token=%@&action=%@&recurring_id=%@&history_id=%@&device_type=%@",
+                                        [json objectForKey:@"device_token_key"],
+                                        [json objectForKey:@"device_token"],
+                                        [userInfo objectForKey:@"action"],
+                                        [userInfo objectForKey:@"recurring_id"],
+                                        [userInfo objectForKey:@"history_id"],
+                                        @"apns"];
+                    NSLog(@"POST PARAMS -> %@", params);
+                    NSLog(@"POST RESULT -> %@", [self sendPOST:url withParams:params]);
+                }
+            }
+            
+        }];
+    }
+}
+
+- (NSString *) sendPOST:(NSString *)endpoint withParams:(NSString *)params {
+    NSData *postData = [params dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
+    NSString *postLength = [NSString stringWithFormat:@"%lu",[postData length]];
+
+
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    [request setHTTPMethod:@"POST"];
+    [request setURL:[NSURL URLWithString:endpoint]];
+    [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
+    [request setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-Type"];
+    [request setHTTPBody:postData];
+
+    NSError *error = nil;
+    NSHTTPURLResponse *responseCode = nil;
+
+    NSData *oResponseData = [NSURLConnection sendSynchronousRequest:request returningResponse:&responseCode error:&error];
+
+    if([responseCode statusCode] != 200){
+        NSLog(@"Error getting %@, HTTP status code %li", endpoint, (long)[responseCode statusCode]);
+        return nil;
+    }
+
+    return [[NSString alloc] initWithData:oResponseData encoding:NSUTF8StringEncoding];
+}
+
+@end


### PR DESCRIPTION
## PR Type
Added options for selectable items: `foreground` will allow to open application after select option. `destructive` make button in red color; 

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

`pn-actions.json` example
```
{
  "PushNotificationActions": [
    {
      "category": "news",
      "actions": [
        {
          "id": "read", "title": "Read", "foreground": "true"
        },
        {
          "id": "skip", "title": "Skip", "destructive": "true"
        },
        {
          "id": "add", "title": "Add to list"
        }
      ]
    }
  ] 
}
```