### PR TITLE
Added support for Crashlytics didCrashOnPreviousExecution & setCustomKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ To help ensure this plugin is kept updated, new features are added and bugfixes 
     - [setUserProperty](#setuserproperty)
   - [Crashlytics](#crashlytics)
     - [setCrashlyticsCollectionEnabled](#setcrashlyticscollectionenabled)
+    - [didCrashOnPreviousExecution](#didCrashOnPreviousExecution)
     - [isCrashlyticsCollectionEnabled](#iscrashlyticscollectionenabled)
     - [setCrashlyticsUserId](#setcrashlyticsuserid)
     - [sendCrash](#sendcrash)
+    - [setCustomKey](#setCustomKey)
     - [logMessage](#logmessage)
     - [logError](#logerror)
   - [Authentication](#authentication)
@@ -2007,6 +2009,22 @@ FirebasePlugin.setCrashlyticsCollectionEnabled(shouldSetEnabled, function(){
 });
 ```
 
+### didCrashOnPreviousExecution
+Checks whether the app crashed on its previous run.
+
+**Parameters**:
+- {function} success - callback function which will be invoked on success.
+Will be passed a {boolean} indicating whether the app crashed on its previous run.
+- {function} error - (optional) callback function which will be passed a {string} error message as an argument
+
+```javascript
+FirebasePlugin.didCrashOnPreviousExecution(function(didCrashOnPreviousExecution){
+    console.log(`Did crash on previous execution: ${didCrashOnPreviousExecution}`));
+}, function(error){
+    console.error(`Error getting Crashlytics did crash on previous execution: ${error}`);
+});
+```
+
 ### isCrashlyticsCollectionEnabled
 Indicates whether Crashlytics collection setting is currently enabled.
 
@@ -2023,7 +2041,6 @@ FirebasePlugin.isCrashlyticsCollectionEnabled(function(enabled){
 });
 ```
 
-
 ### setCrashlyticsUserId
 Set Crashlytics user identifier.
 
@@ -2039,7 +2056,6 @@ See [the Firebase docs for more](https://firebase.google.com/docs/crashlytics/cu
 FirebasePlugin.setCrashlyticsUserId("user_id");
 ```
 
-
 ### sendCrash
 Simulates (causes) a fatal native crash which causes a crash event to be sent to Crashlytics (useful for testing).
 See [the Firebase documentation](https://firebase.google.com/docs/crashlytics/force-a-crash?authuser=0#force_a_crash_to_test_your_implementation) regarding crash testing.
@@ -2048,6 +2064,36 @@ Crashes will appear under `Event type = "Crashes"` in the Crashlytics console.
 **Parameters**: None
 
 ```javascript
+FirebasePlugin.sendCrash();
+```
+
+### setCustomKey
+Records a custom key and value to be associated with subsequent fatal and non-fatal reports.
+
+Multiple calls to this method with the same key will update the value for that key.
+
+The value of any key at the time of a fatal or non-fatal event will be associated with that event.
+
+Keys and associated values are visible in the session view on the Firebase Crashlytics console.
+
+A maximum of 64 key/value pairs can be written, and new keys added beyond that limit will be ignored. Keys or values that exceed 1024 characters will be truncated.
+
+**Parameters**:
+- {string} key - A unique key
+- {string | number | boolean} value - 	A value to be associated with the given key
+- {function} success - (optional) callback function which will be invoked on success
+- {function} error - (optional) callback function which will be passed a {string} error message as an argument
+
+```javascript
+FirebasePlugin.setCustomKey('number', 3.5, function(){
+        console.log("set custom key: number, with value: 3.5");
+    },function(error){
+        console.error("Failed to set-custom key", error);
+    });
+FirebasePlugin.setCustomKey('bool', true);
+FirebasePlugin.setCustomKey('string', 'Ipsum lorem');
+// Following is just used to trigger report for Firebase
+FirebasePlugin.logMessage("about to send a crash for testing!");
 FirebasePlugin.sendCrash();
 ```
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To help ensure this plugin is kept updated, new features are added and bugfixes 
     - [isCrashlyticsCollectionEnabled](#iscrashlyticscollectionenabled)
     - [setCrashlyticsUserId](#setcrashlyticsuserid)
     - [sendCrash](#sendcrash)
-    - [setCustomKey](#setCustomKey)
+    - [setCrashlyticsCustomKey](#setCrashlyticsCustomKey)
     - [logMessage](#logmessage)
     - [logError](#logerror)
   - [Authentication](#authentication)
@@ -2067,7 +2067,7 @@ Crashes will appear under `Event type = "Crashes"` in the Crashlytics console.
 FirebasePlugin.sendCrash();
 ```
 
-### setCustomKey
+### setCrashlyticsCustomKey
 Records a custom key and value to be associated with subsequent fatal and non-fatal reports.
 
 Multiple calls to this method with the same key will update the value for that key.
@@ -2085,13 +2085,13 @@ A maximum of 64 key/value pairs can be written, and new keys added beyond that l
 - {function} error - (optional) callback function which will be passed a {string} error message as an argument
 
 ```javascript
-FirebasePlugin.setCustomKey('number', 3.5, function(){
+FirebasePlugin.setCrashlyticsCustomKey('number', 3.5, function(){
         console.log("set custom key: number, with value: 3.5");
     },function(error){
         console.error("Failed to set-custom key", error);
     });
-FirebasePlugin.setCustomKey('bool', true);
-FirebasePlugin.setCustomKey('string', 'Ipsum lorem');
+FirebasePlugin.setCrashlyticsCustomKey('bool', true);
+FirebasePlugin.setCrashlyticsCustomKey('string', 'Ipsum lorem');
 // Following is just used to trigger report for Firebase
 FirebasePlugin.logMessage("about to send a crash for testing!");
 FirebasePlugin.sendCrash();

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -354,8 +354,8 @@ public class FirebasePlugin extends CordovaPlugin {
             } else if (action.equals("clearAllNotifications")) {
                 this.clearAllNotifications(callbackContext);
                 return true;
-            } else if (action.equals("setCustomKey")) {
-                this.setCustomKey(callbackContext, args);
+            } else if (action.equals("setCrashlyticsCustomKey")) {
+                this.setCrashlyticsCustomKey(callbackContext, args);
                 return true;
             } else if (action.equals("logMessage")) {
                 logMessage(args, callbackContext);
@@ -763,7 +763,7 @@ public class FirebasePlugin extends CordovaPlugin {
         });
     }
 
-    private void setCustomKey(final CallbackContext callbackContext, final JSONArray data) {
+    private void setCrashlyticsCustomKey(final CallbackContext callbackContext, final JSONArray data) {
         cordova.getThreadPool().execute(new Runnable() {
             public void run() {
                 if(isCrashlyticsEnabled()){

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -255,6 +255,9 @@ public class FirebasePlugin extends CordovaPlugin {
             } else if (action.equals("getInfo")) {
                 this.getInfo(callbackContext);
                 return true;
+            } else if (action.equals("didCrashOnPreviousExecution")) {
+                this.didCrashOnPreviousExecution(callbackContext);
+                return true;
             } else if (action.equals("setConfigSettings")) {
                 this.setConfigSettings(callbackContext, args.getJSONObject(0));
                 return true;
@@ -350,6 +353,9 @@ public class FirebasePlugin extends CordovaPlugin {
                 return true;
             } else if (action.equals("clearAllNotifications")) {
                 this.clearAllNotifications(callbackContext);
+                return true;
+            } else if (action.equals("setCustomKey")) {
+                this.setCustomKey(callbackContext, args);
                 return true;
             } else if (action.equals("logMessage")) {
                 logMessage(args, callbackContext);
@@ -757,6 +763,41 @@ public class FirebasePlugin extends CordovaPlugin {
         });
     }
 
+    private void setCustomKey(final CallbackContext callbackContext, final JSONArray data) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                if(isCrashlyticsEnabled()){
+                    try {
+                        Object value = data.get(1);
+                        // Floats can be omitted since they're not passed through JSONArray
+                        if(value instanceof Integer) {
+                            firebaseCrashlytics.setCustomKey(data.getString(0), data.getInt(1));
+                            callbackContext.success();
+                        }else if (value instanceof Double) {
+                            firebaseCrashlytics.setCustomKey(data.getString(0), data.getDouble(1));
+                            callbackContext.success();
+                        }else if (value instanceof Long) {
+                            firebaseCrashlytics.setCustomKey(data.getString(0), data.getLong(1));
+                            callbackContext.success();
+                        }else if (value instanceof String) {
+                            firebaseCrashlytics.setCustomKey(data.getString(0), data.getString(1));
+                            callbackContext.success();
+                        }else if (value instanceof Boolean) {
+                            firebaseCrashlytics.setCustomKey(data.getString(0), data.getBoolean(1));
+                            callbackContext.success();
+                        }else {
+                            callbackContext.error("Cannot set custom key - Value is not an acceptable type");
+                        }
+                    }catch(Exception e) {
+                        handleExceptionWithContext(e, callbackContext);
+                    }
+                }else{
+                    callbackContext.error("Cannot set custom key - Crashlytics collection is disabled");
+                }
+            }
+        });
+    }
+
     private void logMessage(final JSONArray data,
                             final CallbackContext callbackContext) {
 
@@ -917,6 +958,22 @@ public class FirebasePlugin extends CordovaPlugin {
                     callbackContext.success(info);
                 } catch (Exception e) {
                     handleExceptionWithContext(e, callbackContext);
+                }
+            }
+        });
+    }
+
+    private void didCrashOnPreviousExecution(final CallbackContext callbackContext) {
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                if(isCrashlyticsEnabled()){
+                    try {
+                        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, firebaseCrashlytics.didCrashOnPreviousExecution()));
+                    } catch (Exception e) {
+                        handleExceptionWithContext(e, callbackContext);
+                    }
+                } else{
+                    callbackContext.error("Cannot query didCrashOnPreviousExecution - Crashlytics collection is disabled");
                 }
             }
         });

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -62,7 +62,7 @@
 - (void)setCrashlyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
 - (void)isCrashlyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
 - (void)didCrashOnPreviousExecution:(CDVInvokedUrlCommand *)command;
-- (void)setCustomKey:(CDVInvokedUrlCommand *)command;
+- (void)setCrashlyticsCustomKey:(CDVInvokedUrlCommand *)command;
 - (void)logError:(CDVInvokedUrlCommand*)command;
 - (void)logMessage:(CDVInvokedUrlCommand*)command;
 - (void)sendCrash:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -61,6 +61,8 @@
 // Crashlytics
 - (void)setCrashlyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
 - (void)isCrashlyticsCollectionEnabled:(CDVInvokedUrlCommand*)command;
+- (void)didCrashOnPreviousExecution:(CDVInvokedUrlCommand *)command;
+- (void)setCustomKey:(CDVInvokedUrlCommand *)command;
 - (void)logError:(CDVInvokedUrlCommand*)command;
 - (void)logMessage:(CDVInvokedUrlCommand*)command;
 - (void)sendCrash:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -72,7 +72,7 @@ static NSDictionary* googlePlist;
         if([self getGooglePlistFlagWithDefaultValue:FIREBASE_PERFORMANCE_COLLECTION_ENABLED defaultValue:YES]){
             [self setPreferenceFlag:FIREBASE_PERFORMANCE_COLLECTION_ENABLED flag:YES];
         }
-        
+
         // Set actionable categories if pn-actions.json exist in bundle
         [self setActionableNotifications];
 
@@ -90,7 +90,7 @@ static NSDictionary* googlePlist;
 
 // Dynamic actions from pn-actions.json
 - (void)setActionableNotifications {
-    
+
     // Parse JSON
     NSString *path = [[NSBundle mainBundle] pathForResource:@"pn-actions" ofType:@"json"];
     NSData *data = [NSData dataWithContentsOfFile:path];
@@ -102,20 +102,20 @@ static NSDictionary* googlePlist;
     for (NSDictionary *item in actionsArray) {
         NSMutableArray *buttons = [NSMutableArray new];
         NSString *category = [item objectForKey:@"category"];
-        
+
         NSArray *actions = [item objectForKey:@"actions"];
         for (NSDictionary *action in actions) {
             NSString *actionId = [action objectForKey:@"id"];
             NSString *actionTitle = [action objectForKey:@"title"];
-        
+
             [buttons addObject:[UNNotificationAction actionWithIdentifier:actionId
                 title:NSLocalizedString(actionTitle, nil) options:UNNotificationActionOptionNone]];
         }
-        
+
         [categories addObject:[UNNotificationCategory categoryWithIdentifier:category
                     actions:buttons intentIdentifiers:@[] options:UNNotificationCategoryOptionNone]];
     }
-    
+
     // Initialize categories
     [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
 }
@@ -1159,7 +1159,7 @@ static NSDictionary* googlePlist;
     }];
 }
 
-- (void)setCustomKey:(CDVInvokedUrlCommand*)command{
+- (void)setCrashlyticsCustomKey:(CDVInvokedUrlCommand*)command{
     [self.commandDelegate runInBackground:^{
         @try {
             NSString* key = [command argumentAtIndex:0 withDefault:@""];


### PR DESCRIPTION
## PR Type
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
- [x] Testing has been carried out for the changes have been added
- [x] Regression testing has been carried out for existing functionality
- [x] Docs have been added / updated

## What is the purpose of this PR?
Closes #434.
Adds support for Firebase Crashlytics `didCrashOnPreviousExecution` & `setCustomKey`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

## What testing has been done on the changes in the PR?
Tested on Android Phone and iOS iPad

## What testing has been done on existing functionality?
Ensured push notifications and crashlytics logging continued to work.
