### PR TITLE
fix: Using AfterEvaluate to postpone the execution of apply plugin com.google.gms.google-services

### DIFF
--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -36,10 +36,12 @@ android {
 }
 
 cdvPluginPostBuildExtras.add({
-    rootProject.subprojects {
-        if (name == "app") {
-            if (!plugins.hasPlugin('com.google.gms.google-services')) {
-                apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+    afterEvaluate {
+        rootProject.subprojects {
+            if (name == "app") {
+                if (!plugins.hasPlugin('com.google.gms.google-services')) {
+                    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+                }
             }
         }
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.


## What is the purpose of this PR?
Fix issue described in https://github.com/dpa99c/cordova-plugin-firebasex/issues/536

We are using `AfterEvaluate` instead of [cordova android guideline](https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html) because if we use it it will introduce a break change. Older cordova android version will be broken.

In next major version it could be good remove this lines and use:
```
<config-file target="config.xml" parent="/*">
    <preference name="GradlePluginGoogleServicesEnabled" value="true" />
    <preference name="GradlePluginGoogleServicesVersion" value="4.2.0" />
</config-file>
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
Used test project to test if it's correct. Steps to reproduce inside git issue
