### PR TITLE
(feat): support for AppNotificationSettingsButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,15 @@ Notes:
 - If your app is in the background/not running when the notification message arrives and a system notification is displayed, if the user chooses an action (instead of tapping the notification dialog body), your app will not be launched/foregrounded but [`onMessageReceived()`](#onmessagereceived) will be invoked, enabling your app code to handle the user's action selection silently in the background.
 - You can test out actionable notifications by building and running [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) app and sending the [ios_notification_actionable.json](https://github.com/dpa99c/cordova-plugin-firebasex-test/blob/master/messages/ios_notification_actionable.json) FCM message using the [built-in FCM v1 HTTP API client](https://github.com/dpa99c/cordova-plugin-firebasex-test#messaging-client) which contains a category defined in the example [pn-actions.json](https://github.com/dpa99c/cordova-plugin-firebasex-test/blob/master/res/ios/pn-actions.json).
 
+### iOS notification settings button
+
+<img width="300" src="https://i.stack.imgur.com/84LDU.jpg">
+
+Adding such a Button is possible with this Plugin.
+To enable this Feature, you need to pass `true` for **requestWithProvidesAppNotificationSettings** when you [request the Permission](#grantpermission).
+
+You then need to subscribe to `onOpenSettings` and open your apps notification settings page.
+
 ## Data messages
 FCM data messages are sent as an arbitrary k/v structure and by default are passed to the app for it to handle them.
 
@@ -1539,6 +1548,22 @@ FirebasePlugin.onApnsTokenReceived(function(apnsToken) {
 });
 ```
 
+### onOpenSettings
+iOS only
+Registers a callback function to invoke when the AppNotificationSettingsButton is tapped by the user
+
+**Parameters**:
+- {function} success - callback function which will be invoked without any argument
+- {function} error - callback function which will be passed a {string} error message as an argument
+
+```javascript
+FirebasePlugin.onOpenSettings(function() {
+    console.log("Redirect to App Notification Settings Page here");
+}, function(error) {
+    console.error(error);
+});
+```
+
 ### onMessageReceived
 Registers a callback function to invoke when:
 - a notification or data message is received by the app
@@ -1595,6 +1620,7 @@ iOS only (Android will always return true).
 **Parameters**:
 - {function} success - callback function which will be passed the {boolean} permission result as an argument
 - {function} error - callback function which will be passed a {string} error message as an argument
+- {boolean} requestWithProvidesAppNotificationSettings - boolean which indicates if app provides AppNotificationSettingsButton (**iOS12+ only**)
 
 ```javascript
 FirebasePlugin.grantPermission(function(hasPermission){

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -374,6 +374,16 @@ didDisconnectWithUser:(GIDGoogleUser *)user
     [FirebasePlugin.firebasePlugin _logError:[NSString stringWithFormat:@"didFailToRegisterForRemoteNotificationsWithError: %@", error.description]];
 }
 
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center openSettingsForNotification:(UNNotification *)notification
+{
+    @try {
+        [FirebasePlugin.firebasePlugin sendOpenNotificationSettings];
+    } @catch (NSException *exception) {
+        [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
+    }
+}
+
+
 // Asks the delegate how to handle a notification that arrived while the app was running in the foreground
 // Called when an APS notification arrives when app is in foreground
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -44,9 +44,11 @@
 - (void)subscribe:(CDVInvokedUrlCommand*)command;
 - (void)unsubscribe:(CDVInvokedUrlCommand*)command;
 - (void)unregister:(CDVInvokedUrlCommand*)command;
+- (void)onOpenSettings:(CDVInvokedUrlCommand*)command;
 - (void)onMessageReceived:(CDVInvokedUrlCommand*)command;
 - (void)onTokenRefresh:(CDVInvokedUrlCommand*)command;
 - (void)onApnsTokenReceived:(CDVInvokedUrlCommand *)command;
+- (void)sendOpenNotificationSettings;
 - (void)sendNotification:(NSDictionary*)userInfo;
 - (void)sendToken:(NSString*)token;
 - (void)sendApnsToken:(NSString*)token;
@@ -121,6 +123,7 @@
 - (void)listChannels:(CDVInvokedUrlCommand *)command;
 
 @property (nonatomic, copy) NSString *notificationCallbackId;
+@property (nonatomic, copy) NSString *openSettingsCallbackId;
 @property (nonatomic, copy) NSString *tokenRefreshCallbackId;
 @property (nonatomic, copy) NSString *apnsTokenRefreshCallbackId;
 @property (nonatomic, copy) NSString *googleSignInCallbackId;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,9 +35,14 @@ export interface FirebasePlugin {
         success: (value: object) => void,
         error: (err: string) => void
     ): void
+    onOpenSettings(
+        success: () => void,
+        error: (err: string) => void
+    ): void
     grantPermission(
         success: (value: boolean) => void,
-        error: (err: string) => void
+        error: (err: string) => void,
+        requestWithProvidesAppNotificationSettings?: boolean
     ): void
     hasPermission(
         success: (value: boolean) => void,

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -74,6 +74,10 @@ exports.setAutoInitEnabled = function (enabled, success, error) {
 };
 
 // Notifications - iOS-only
+exports.onOpenSettings = function (success, error) {
+  exec(success, error, "FirebasePlugin", "onOpenSettings", []);
+};
+
 exports.setBadgeNumber = function (number, success, error) {
     exec(success, error, "FirebasePlugin", "setBadgeNumber", [number]);
 };
@@ -82,8 +86,8 @@ exports.getBadgeNumber = function (success, error) {
     exec(success, error, "FirebasePlugin", "getBadgeNumber", []);
 };
 
-exports.grantPermission = function (success, error) {
-    exec(ensureBooleanFn(success), error, "FirebasePlugin", "grantPermission", []);
+exports.grantPermission = function (success, error, requestWithProvidesAppNotificationSettings) {
+    exec(ensureBooleanFn(success), error, "FirebasePlugin", "grantPermission", [ensureBoolean(requestWithProvidesAppNotificationSettings)]);
 };
 
 exports.hasPermission = function (success, error) {


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [X] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

Support for [UNAuthorizationOptionProvidesAppNotificationSettings](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions/unauthorizationoptionprovidesappnotificationsettings?language=objc)

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information

This PR is not finished yet, BECAUSE: While testing the delegate Methode wan't called when app was terminated and opened via the Button from Settings. Maybe you can have a look here?
