### PR TITLE
Adding base class to to prevent iOS build error

### DIFF
--- a/src/ios/FirebasePluginMessageReceiverManager.h
+++ b/src/ios/FirebasePluginMessageReceiverManager.h
@@ -1,6 +1,6 @@
 #import "FirebasePluginMessageReceiver.h"
 
-@interface FirebasePluginMessageReceiverManager
+@interface FirebasePluginMessageReceiverManager : NSObject
 + (void) register:(FirebasePluginMessageReceiver *)receiver;
 + (bool) sendNotification:(NSDictionary *)userInfo;
 @end


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
This is to commit the fix mentioned in #493 to the plugin directly, so that it will not need to be manually added every time a build is run. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X ] No

Test project is currently not building for what I think are unrelated reasons: 
```
'FirebaseCore/FirebaseCore.h' file not found.
Could not build module 'Firebase'
```

I have tested this fix on my own project, and it does fix the bug mentioned in #493.