### PR TITLE
Pass Oauth details back to JS layer for use with Angularfire authentication

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -453,6 +453,8 @@ public class FirebasePlugin extends CordovaPlugin {
                     JSONObject returnResults = new JSONObject();
                     returnResults.put("instantVerification", true);
                     returnResults.put("id", id);
+                    returnResults.put("idToken", acct.getIdToken());
+                    returnResults.put("accessToken", acct.getServerAuthCode());
                     FirebasePlugin.activityResultCallbackContext.success(returnResults);
                     break;
             }

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -137,6 +137,9 @@ didSignInForUser:(GIDGoogleUser *)user
             NSMutableDictionary* result = [[NSMutableDictionary alloc] init];
             [result setValue:@"true" forKey:@"instantVerification"];
             [result setValue:key forKey:@"id"];
+            [result setValue:authentication.idToken forKey:@"idToken"];
+            [result setValue:authentication.accessToken forKey:@"accessToken"];
+
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
         } else {
           pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.description];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [x] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->


New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
This allows users to use native Google login using the Firebasex plugin, whilst passing the credentials to a JS layer firebase implementation such as Angularfire auth.

Please be kind as this is the first PR I've made on Github.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

I have tested this and it works quite well. There may be some security concerns here and that may be why you haven't done it yet as you're keeping these details within the native layer. I can't see what these security issues are, but there may be a reason for it.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information

Some example code here can shed light on why I introduced these changes. This is essentially what I used this for in my project. I realise most of AngularFire's functions can be replicated through Firebasex, but my application has already been built using AngularFire and I wanted to avoid a re-write.

`import { AngularFireAuth } from '@angular/fire/auth';
import { AngularFirestore } from '@angular/fire/firestore';
import { FirebaseX } from '@ionic-native/firebase-x/ngx';

export class AuthenticateService {
	constructor(private afAuth: AngularFireAuth, private fireStore: AngularFirestore, private firebaseX: FirebaseX) {}

	onLoginSuccessG(accessToken, accessSecret) {
		return new Promise((resolve) => {
			const credential = accessSecret
				? firebase.auth.GoogleAuthProvider.credential(accessToken, accessSecret)
				: firebase.auth.GoogleAuthProvider.credential(accessToken);
			this.afAuth.signInWithCredential(credential).then((response) => {
				resolve(response);
			});
		});
	}

	nativeGoogleOAuthLogin() {
		this.firebaseX
			.authenticateUserWithGoogle(
				'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com'
			)
			.then((response) => {
				const { idToken, accessToken } = response;
				resolve(this.onLoginSuccessG(idToken, accessToken));
			})
			.catch((error) => {
				console.log(error);
				reject(error);
				alert('error:' + JSON.stringify(error));
			});
	}
}`
