### PR TITLE
feat(auth): add idToken on signIn w/ Google response

### DIFF
--- a/README.md
+++ b/README.md
@@ -2645,6 +2645,7 @@ Authenticates the user with a Google account to obtain a credential that can be 
 - {string} clientId - your OAuth 2.0 client ID - [see here](https://developers.google.com/identity/sign-in/android/start-integrating#get_your_backend_servers_oauth_20_client_id) how to obtain it.
 - {function} success - callback function to pass {object} credentials to as an argument. The credential object has the following properties:
     - {string} id - the identifier of a native credential object which can be used for signing in the user.
+    - {string} idToken - the identiy token from Google account. Could be useful if you want to sign-in with on JS layer.
 - {function} error - callback function which will be passed a {string} error message as an argument
 
 Example usage:

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -449,10 +449,13 @@ public class FirebasePlugin extends CordovaPlugin {
                     }
                     AuthCredential credential = GoogleAuthProvider.getCredential(acct.getIdToken(), null);
                     String id = FirebasePlugin.instance.saveAuthCredential(credential);
+                    String idToken = acct.getIdToken();
 
                     JSONObject returnResults = new JSONObject();
                     returnResults.put("instantVerification", true);
                     returnResults.put("id", id);
+                    returnResults.put("idToken", idToken);
+
                     FirebasePlugin.activityResultCallbackContext.success(returnResults);
                     break;
             }

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -134,9 +134,11 @@ didSignInForUser:(GIDGoogleUser *)user
                                            accessToken:authentication.accessToken];
             
             NSNumber* key = [[FirebasePlugin firebasePlugin] saveAuthCredential:credential];
+            NSString *idToken = user.authentication.idToken;
             NSMutableDictionary* result = [[NSMutableDictionary alloc] init];
             [result setValue:@"true" forKey:@"instantVerification"];
             [result setValue:key forKey:@"id"];
+            [result setValue:idToken forKey:@"idToken"];
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
         } else {
           pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.description];


### PR DESCRIPTION
- should allow to propagate the token to the web view layer and sign-in within both tiers (native and web)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [x] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [x] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

It's a common case to authenticate on native layer and propagate idToken to the web view layer. After the sign-in process completes, the user will be signed in within both tiers, and we can use web specific sdks, as AngularFire for example, to handle Firebase account.
It's widely used on Cordova/Capacitor communities, as exposed by [Dayana Jabif (ionicThemes) on ionic forum](https://forum.ionicframework.com/t/help-how-do-i-integrate-native-firebase-google-login-with-my-capacitor-app/197601/2)

> I used [baumblatt/capacitor-firebase-auth](https://github.com/baumblatt/capacitor-firebase-auth) to perform native login with Google, Facebook and Twitter and it works like a charm!
The plugin handles the authentication on Native layer and propagate the token to the web view layer. After the sign-in process completes, the user will be signed in within both tiers.

On [medium: Implement Google login in Ionic 5 apps using Firebase](https://medium.com/enappd/implement-google-login-in-ionic-apps-using-firebase-f659fd71dfb5), the author uses [EddyVerbruggen/cordova-plugin-googleplus](https://github.com/EddyVerbruggen/cordova-plugin-googleplus/blob/master/src/android/GooglePlus.java), [this plugin returns idToken on signIn response](https://github.com/EddyVerbruggen/cordova-plugin-googleplus/blob/master/src/android/GooglePlus.java#L352)

Similar approach has been shared on [Simon Grimm (ionicacademy): How to use Sign In with Apple inside Ionic for Firebase Authentication](https://ionicacademy.com/sing-in-with-apple-firebase/), using [rlfrahm/capacitor-apple-login](https://github.com/rlfrahm/capacitor-apple-login) plugin, native signInWithApple returns the idToken and is used on JS layer to signInWithCredential.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

I've updated own corporate project with this PR on both platforms, iOS and Android, works fine! 

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information

If this approach is ok, I can I fix https://github.com/dpa99c/cordova-plugin-firebasex/issues/551 related to [sign-in w/ Apple](https://firebase.google.com/docs/auth/android/apple), following same logic.