### PR TITLE
Support Firebase Authentication emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2839,6 +2839,26 @@ Example usage:
     });
 ```
 
+### useAuthEmulator
+Instruments your app to talk to the [Firebase Authentication emulator](https://firebase.google.com/docs/emulator-suite/connect_auth).
+
+
+**Parameters**:
+- {string} host - hostname or IP address of the Authentication emulator.
+- {integer} port - port of the Authentication emulator.
+- {function} success - callback function to call on success
+- {function} error - callback function which will be passed a {string} error message as an argument
+
+Example usage:
+
+```javascript
+FirebasePlugin.useAuthEmulator('localhost', 9099, function() {
+    console.log("Using Firebase Authentication emulator");
+}, function(error) {
+    console.error("Failed to enable the Firebase Authentication emulator", error);
+});
+```
+
 ## Remote Config
 
 ### fetch

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1743,6 +1743,7 @@ public class FirebasePlugin extends CordovaPlugin {
                     }
 
                     FirebaseAuth.getInstance().useEmulator(host, port);
+                    callbackContext.success();
                 } catch (Exception e) {
                     handleExceptionWithContext(e, callbackContext);
                 }

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -182,7 +182,7 @@ public class FirebasePlugin extends CordovaPlugin {
                     authStateListener = new AuthStateListener();
                     FirebaseAuth.getInstance().addAuthStateListener(authStateListener);
 
-                    firestore = FirebaseFirestore.getInstance();                  
+                    firestore = FirebaseFirestore.getInstance();
                     functions = FirebaseFunctions.getInstance();
 
                     gson = new GsonBuilder()
@@ -322,6 +322,8 @@ public class FirebasePlugin extends CordovaPlugin {
                 this.sendUserPasswordResetEmail(callbackContext, args);
             } else if (action.equals("deleteUser")) {
                 this.deleteUser(callbackContext, args);
+            } else if (action.equals("useAuthEmulator")) {
+                this.useAuthEmulator(callbackContext, args);
             } else if (action.equals("startTrace")) {
                 this.startTrace(callbackContext, args.getString(0));
             } else if (action.equals("incrementCounter")) {
@@ -1716,6 +1718,31 @@ public class FirebasePlugin extends CordovaPlugin {
             public void run() {
                 try {
                     FirebaseAuth.getInstance().signInAnonymously().addOnCompleteListener(cordova.getActivity(), new AuthResultOnCompleteListener(callbackContext));
+                } catch (Exception e) {
+                    handleExceptionWithContext(e, callbackContext);
+                }
+            }
+        });
+    }
+
+    public void useAuthEmulator(final CallbackContext callbackContext, final JSONArray args){
+        cordova.getThreadPool().execute(new Runnable() {
+            public void run() {
+                try {
+                    String host = args.getString(0);
+                    Integer port = args.getInt(1);
+
+                    if(host == null || host.equals("")){
+                        callbackContext.error("host must be specified");
+                        return;
+                    }
+
+                    if(port == null){
+                        callbackContext.error("port must be specified");
+                        return;
+                    }
+
+                    FirebaseAuth.getInstance().useEmulator(host, port);
                 } catch (Exception e) {
                     handleExceptionWithContext(e, callbackContext);
                 }

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -31,6 +31,7 @@
 - (void)updateUserPassword:(CDVInvokedUrlCommand*)command;
 - (void)sendUserPasswordResetEmail:(CDVInvokedUrlCommand*)command;
 - (void)deleteUser:(CDVInvokedUrlCommand*)command;
+- (void)useAuthEmulator:(CDVInvokedUrlCommand*)command;
 
 // Remote notifications
 - (void)getId:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -135,7 +135,7 @@ static NSMutableDictionary* traces;
 
         // Initialize categories
         [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
-        
+
         // Initialize installation ID change listner
         __weak __auto_type weakSelf = self;
         self.installationIDObserver = [[NSNotificationCenter defaultCenter]
@@ -306,7 +306,7 @@ static NSMutableDictionary* traces;
                             authOptions = authOptions|UNAuthorizationOptionProvidesAppNotificationSettings;
                         }
                     }
-                
+
                     [[UNUserNotificationCenter currentNotificationCenter]
                      requestAuthorizationWithOptions:authOptions
                      completionHandler:^(BOOL granted, NSError * _Nullable error) {
@@ -1022,6 +1022,16 @@ static NSMutableDictionary* traces;
   return result;
 }
 
+- (void)useAuthEmulator:(CDVInvokedUrlCommand *)command {
+    NSString* host = [command.arguments objectAtIndex:0];
+    NSInteger port = [[command.arguments objectAtIndex:1] integerValue];
+    @try {
+        [[FIRAuth auth] useEmulatorWithHost:host port:port];
+    }@catch (NSException *exception) {
+        [self handlePluginExceptionWithContext:exception :command];
+    }
+}
+
 /*
  * Analytics
  */
@@ -1468,7 +1478,7 @@ static NSMutableDictionary* traces;
     [self.commandDelegate runInBackground:^{
         @try {
             NSString* traceName = [command.arguments objectAtIndex:0];
-            
+
             @synchronized (traces) {
                 FIRTrace* trace = [traces objectForKey:traceName];
 
@@ -1477,7 +1487,7 @@ static NSMutableDictionary* traces;
                     [traces setObject:trace forKey:traceName ];
                 }
             }
-            
+
             CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
             [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         }@catch (NSException *exception) {
@@ -1981,7 +1991,7 @@ static NSMutableDictionary* traces;
 
 - (void) getInstallationToken:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
-        @try {            
+        @try {
             [[FIRInstallations installations] authTokenForcingRefresh:true
                                                            completion:^(FIRInstallationsAuthTokenResult *result, NSError *error) {
               if (error != nil) {

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -1027,6 +1027,7 @@ static NSMutableDictionary* traces;
     NSInteger port = [[command.arguments objectAtIndex:1] integerValue];
     @try {
         [[FIRAuth auth] useEmulatorWithHost:host port:port];
+        [self sendPluginSuccess:command];
     }@catch (NSException *exception) {
         [self handlePluginExceptionWithContext:exception :command];
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -240,6 +240,12 @@ export interface FirebasePlugin {
     registerAuthStateChangeListener(
         fn: (userSignedIn: boolean) => void,
     ): void
+    useAuthEmulator(
+        host: string,
+        port: number,
+        success?: () => void,
+        error?: (err: string) => void
+    ): void
     fetch(
         cacheExpirationSeconds: number,
         success: () => void,

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -362,6 +362,10 @@ exports.registerAuthStateChangeListener = function(fn){
     onAuthStateChangeCallback = fn;
 };
 
+exports.useAuthEmulator = function (host, port, success, error) {
+    exec(success, error, "FirebasePlugin", "useAuthEmulator", [host, port]);
+};
+
 // Firestore
 exports.addDocumentToFirestoreCollection = function (document, collection, success, error) {
     if(typeof collection !== 'string') return error("'collection' must be a string specifying the Firestore collection name");


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
Please check your PR fulfills the following requirements:

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [x] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [x] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
This change adds support for the [Firebase Authentication emulator](https://firebase.google.com/docs/emulator-suite/connect_auth) which is part of the Firebase Local Emulator Suite. It allows authentication to be handled by a local emulator suite rather than a real Firebase project instance.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
This PR has been tested with the useAuthEmulator function called after the FirebasePlugin has been initialized. It successfully connects and uses the configured authentication emulator for Firebase Authentication operations.

## What testing has been done on existing functionality?
This PR has been tested without calling the useAuthEmulator function. All existing Firebase Authentication behaviour is unchanged.

## Other information
The changes in this PR have been used in a production app available on both the App Store and Google Play Store.