### PR TITLE
Use OAuthProvider when available during linkUserWithCredential

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -1433,6 +1433,15 @@ public class FirebasePlugin extends CordovaPlugin {
                         return;
                     }
 
+                    OAuthProvider authProvider = FirebasePlugin.instance.obtainAuthProvider(jsonCredential);
+                    if(authProvider != null){
+                        FirebasePlugin.instance.authResultCallbackContext = callbackContext;
+                        FirebaseAuth.getInstance().getCurrentUser().startActivityForLinkWithProvider(FirebasePlugin.cordovaActivity, authProvider)
+                                .addOnSuccessListener(new AuthResultOnSuccessListener())
+                                .addOnFailureListener(new AuthResultOnFailureListener());
+                        return;
+                    }
+
                     //ELSE
                     callbackContext.error("Specified native auth credential id does not exist");
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

## What is the purpose of this PR?
This PR fetches the interim OAuthProvider when calling linkUserWithCredential. Without it, using OAuth based authentication before linking a user with a credential would fail. (e.g. using authenticateUserWithApple to retrieve a credential for linkUserWithCredential on Android would not successfully link the user with their Apple ID.)

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
This PR has been tested on an Android device using a real Apple ID, linked to an existing Firebase user.

## What testing has been done on existing functionality?
This PR has been tested using Sign in With Google and sign in with email/password ahead of linking to an existing Firebase user.

## Other information
The changes in this PR have also been used in a production app available on both the App Store and Google Play Store.