### PR TITLE
Use precompiled FirebaseFirestore on first pod install

### DIFF
--- a/scripts/ios/before_plugin_install.js
+++ b/scripts/ios/before_plugin_install.js
@@ -1,10 +1,31 @@
 var execSync = require('child_process').execSync;
 var semver = require('semver');
+var path = require("path");
+const { parsePluginXml, writeJsonToXmlFile, getPluginId, parsePluginVariables, setContext } = require('../lib/utilities');
+
+var pluginVariables = {};
 
 var minCocoapodsVersion = "^1.11.2";
 
 module.exports = function(context) {
     checkCocoapodsVersion();
+
+    setContext(context);
+
+    //get platform from the context supplied by cordova
+    var platforms = context.opts.cordova.platforms;
+
+    pluginVariables = parsePluginVariables();
+
+    if(platforms.includes('ios') && pluginVariables.IOS_USE_PRECOMPILED_FIRESTORE_POD==='true'){
+        const pluginJSON=parsePluginXml();
+        const iosPlatform = pluginJSON.plugin.platform.find((platform) => platform._attributes.name === 'ios');
+        const firestorePod = iosPlatform.podspec.pods.pod.find((pod) => pod._attributes.name === 'Firebase/Firestore');
+        firestorePod._attributes.tag = firestorePod._attributes.spec;
+        firestorePod._attributes.git = 'https://github.com/invertase/firestore-ios-sdk-frameworks.git';
+        delete firestorePod._attributes.spec;
+        writeJsonToXmlFile(pluginJSON, path.resolve("plugins/"+getPluginId()+"/plugin.xml"))
+    }
 };
 
 function checkCocoapodsVersion(){


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
Updates plugin.xml to use the precompiled version of FirebaseFirestore (if setting is enabled) on the first `pod install` 

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information
