### PR TITLE
(iOS) Use standard pod for Firestore by default - patch cli_build

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -147,7 +147,7 @@
 				<pod name="Firebase/Messaging" spec="9.1.0"/>
 				<pod name="Firebase/Performance" spec="9.1.0"/>
 				<pod name="Firebase/RemoteConfig" spec="9.1.0"/>
-				<pod name="FirebaseFirestore" git="https://github.com/invertase/firestore-ios-sdk-frameworks.git" tag="9.1.0"/>
+				<pod name="Firebase/Firestore" spec="9.1.0"/>
 				<pod name="Firebase/Crashlytics" spec="9.1.0"/>
 				<pod name="Firebase/Functions" spec="9.1.0"/>
 				<pod name="Firebase/Installations" spec="9.1.0"/>


### PR DESCRIPTION
The latest code expects that the pod for Firestore is the default. This change was included in `master` (at d1fb68a) but seems was lost in the merge to `cli_build`

d1fb68a - (iOS) Use standard pod for Firestore by default but add `IOS_USE_PRECOMPILED_FIRESTORE_POD` plugin variable to switch to using pre-built version.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [x] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [x] Documentation has been added / updated
- [x] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
Fix the `cli_build` branch to function as described in the README.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

Technically I would call this a breaking change for the `cli_build` because effectively it changes the default behavior, despite it bringing the code inline with `master` functionality and the documentation.

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

Our builds dependent on the `cli_build` branch now work as described in the README. Specifically the variable `IOS_USE_PRECOMPILED_FIRESTORE_POD` now works as documented when on the `cli_build` branch.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

Tested installing plugin on `cli_build` branch with all possible combinations of `IOS_USE_PRECOMPILED_FIRESTORE_POD` and `IOS_FIREBASE_SDK_VERSION` parameters set and unset.


## Other information
