### PR TITLE
firebase-config 21.1.0 to 21.0.2

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -65,7 +65,7 @@
 		<preference name="ANDROID_PLAY_SERVICES_AUTH_VERSION" default="20.2.0" />
 		<preference name="ANDROID_FIREBASE_ANALYTICS_VERSION" default="21.0.0" />
 		<preference name="ANDROID_FIREBASE_MESSAGING_VERSION" default="23.0.5" />
-		<preference name="ANDROID_FIREBASE_CONFIG_VERSION" default="21.1.0" />
+		<preference name="ANDROID_FIREBASE_CONFIG_VERSION" default="21.0.2" />
 		<preference name="ANDROID_FIREBASE_PERF_VERSION" default="20.0.6" />
 		<preference name="ANDROID_FIREBASE_AUTH_VERSION" default="21.0.4" />
 		<preference name="ANDROID_FIREBASE_INAPPMESSAGING_VERSION" default="20.1.2" />


### PR DESCRIPTION
## com.google.firebase:firebase-config:21.1.0  -> It's decrape. (Google show a warning when you try to upload your APP to the Play Store) 

## Google recommends downgrading to the most stable version 21.0.2



<!-- Please check the one that applies to this PR using "x". -->
- [x ] Bugfix


