### PR TITLE
Add the authorization code to the credential object returned after authentication via Sign in with Apple

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -499,9 +499,14 @@ didDisconnectWithUser:(GIDGoogleUser *)user
                         rawNonce:rawNonce];
                     
                     NSNumber* key = [[FirebasePlugin firebasePlugin] saveAuthCredential:credential];
+                    NSString *authorizationCode = [[NSString alloc] initWithData:appleIDCredential.authorizationCode
+                                                                        encoding:NSUTF8StringEncoding];
                     NSMutableDictionary* result = [[NSMutableDictionary alloc] init];
                     [result setValue:@"true" forKey:@"instantVerification"];
                     [result setValue:key forKey:@"id"];
+                    if(authorizationCode != nil){
+                        [result setValue:authorizationCode forKey:@"authorizationCode"];
+                    }
                     pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
                 }
             }


### PR DESCRIPTION
Add the authorization code to the credential object returned after authentication via Sign in with Apple.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [x] Regression testing has been carried out to ensure no existing functionality is adversely affected

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->

No change to existing functionality.

<!-- Describe the new behaviour added/modified and its purpose. -->

Upon successful authorization using Sign in with Apple, this feature adds the field `authorizationCode` to the `didCompleteWithAuthorization` result.

The Authorization Code is a required piece of information for revoking a Sign in with Apple token, as mandated by Apple (June 30, 2022) when deleting a user's account.

The Firebase team are working on a solution to automatically revoke Sign in with Apple tokens when an account is deleted (ref: https://github.com/firebase/firebase-ios-sdk/issues/9906). In the meantime, giving access to the Authorization Code allows `cordova-plugin-firebasex` users to revoke the token using Apple's REST API. The easiest way to accomplish this is by following the excellent instructions from @jooyoungho here: https://github.com/jooyoungho/apple-token-revoke-in-firebase

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

We have been using this code successfully to revoke Sign in with Apple tokens since the end of June. Our app has successfully passed Apple's review process since this new requirement was instituted.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

Existing plugin functionality continues to work in our app as before.

## Other information

We hope other users of this plugin who are also using Sign in with Apple can benefit from this small change.
