### PR TITLE
(Android) fix: Notification opening app for Android 12 (#763)

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,6 +43,7 @@
 				</intent-filter>
 			</service>
 			<receiver android:name="org.apache.cordova.firebase.OnNotificationOpenReceiver"/>
+			<activity android:name="org.apache.cordova.firebase.OnNotificationReceiverActivity" android:noHistory="true" android:excludeFromRecents="true" android:taskAffinity="" android:theme="@android:style/Theme.Translucent.NoTitleBar" android:exported="true" />
 			<meta-data android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/accent" />
 			<meta-data android:name="com.google.firebase.messaging.default_notification_channel_id" android:value="@string/default_notification_channel_id"/>
 			<meta-data android:name="firebase_analytics_collection_enabled" android:value="$FIREBASE_ANALYTICS_COLLECTION_ENABLED" />
@@ -53,6 +54,7 @@
 		<resource-file src="src/android/cordova-plugin-firebase-strings.xml" target="res/values/cordova-plugin-firebase-strings.xml" />
 		<source-file src="src/android/FirebasePlugin.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/OnNotificationOpenReceiver.java" target-dir="src/org/apache/cordova/firebase" />
+		<source-file src="src/android/OnNotificationReceiverActivity.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessagingService.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessageReceiver.java" target-dir="src/org/apache/cordova/firebase" />
 		<source-file src="src/android/FirebasePluginMessageReceiverManager.java" target-dir="src/org/apache/cordova/firebase" />

--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -13,7 +13,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
 import android.util.Log;
 import android.app.Notification;
 import android.text.TextUtils;

--- a/src/android/OnNotificationReceiverActivity.java
+++ b/src/android/OnNotificationReceiverActivity.java
@@ -1,0 +1,48 @@
+package org.apache.cordova.firebase;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+
+public class OnNotificationReceiverActivity extends Activity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Log.d(FirebasePlugin.TAG, "OnNotificationReceiverActivity.onCreate()");
+        handleNotification(this, getIntent());
+        finish();
+    }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        Log.d(FirebasePlugin.TAG, "OnNotificationReceiverActivity.onNewIntent()");
+        handleNotification(this, intent);
+        finish();
+    }
+
+    private static void handleNotification(Context context, Intent intent) {
+        try{
+            PackageManager pm = context.getPackageManager();
+
+            Intent launchIntent = pm.getLaunchIntentForPackage(context.getPackageName());
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+
+            Bundle data = intent.getExtras();
+            if(!data.containsKey("messageType")) data.putString("messageType", "notification");
+            data.putString("tap", FirebasePlugin.inBackground() ? "background" : "foreground");
+
+            Log.d(FirebasePlugin.TAG, "OnNotificationReceiverActivity.handleNotification(): "+data.toString());
+
+            FirebasePlugin.sendMessage(data, context);
+
+            launchIntent.putExtras(data);
+            context.startActivity(launchIntent);
+        }catch (Exception e){
+            FirebasePlugin.handleExceptionWithoutContext(e);
+        }
+    }
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?

Fix the issue that produces clicking on the notification does not open the app in Android 12+ if the app is in target SDK 31+ #763 

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?

It has been tested to receive notifications and open notifications in Android 13 (SDK 33) and Android 11 (SDK 30)