### PR TITLE
Add support for Android push notification localization in foreground notifications

### DIFF
--- a/src/android/FirebasePluginMessagingService.java
+++ b/src/android/FirebasePluginMessagingService.java
@@ -118,7 +118,11 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
             // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
             String messageType;
             String title = null;
+            String titleLocKey = null;
+            String[] titleLocArgs = null;
             String body = null;
+            String bodyLocKey = null;
+            String[] bodyLocArgs = null;
             String bodyHtml = null;
             String id = null;
             String sound = null;
@@ -142,7 +146,11 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 id = remoteMessage.getMessageId();
                 RemoteMessage.Notification notification = remoteMessage.getNotification();
                 title = notification.getTitle();
+                titleLocKey = notification.getTitleLocalizationKey();
+                titleLocArgs = notification.getTitleLocalizationArgs();
                 body = notification.getBody();
+                bodyLocKey = notification.getBodyLocalizationKey();
+                bodyLocArgs = notification.getBodyLocalizationArgs();
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                     channelId = notification.getChannelId();
                 }
@@ -151,6 +159,14 @@ public class FirebasePluginMessagingService extends FirebaseMessagingService {
                 icon = notification.getIcon();
                 if (notification.getImageUrl() != null) {
                     image = notification.getImageUrl().toString();
+                }
+                if (!TextUtils.isEmpty(titleLocKey)) {
+                    int titleId = getResources().getIdentifier(titleLocKey, "string", getPackageName());
+                    title = String.format(getResources().getString(titleId), (Object[])titleLocArgs);
+                }
+                if (!TextUtils.isEmpty(bodyLocKey)) {
+                    int bodyId = getResources().getIdentifier(bodyLocKey, "string", getPackageName());
+                    body = String.format(getResources().getString(bodyId), (Object[])bodyLocArgs);
                 }
             }else{
                 Log.i(TAG, "Received message: data");


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [x] Feature

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
The purpose of this PR is to address #771 and add support for localization inside of the foreground push notifications.

Mainly, all this PR does is introduce support for the below keys and allows the sender of the notification to have foreground notifications with localized content, which prior to this PR was not supported. Previously the foreground notification would not display at all because the `body` and `title` were null when sending down only localized content.

Missing keys from the foreground notification check which are being added and supported:
- `title_loc_key`
- `title_loc_args`
- `body_loc_key`
- `body_loc_args`

This does not affect existing behavior as it only attempts to set the title and body if the localization key exists. Otherwise it behaves the same as it would have without the added support.

I have run testing in my current solution to check this works as intended with and without the localization in the remote message. Everything looks good. It is a pretty minimal change but very useful. Apologies for not trying this against the example application yet I've just not had the time. 

Obviously if there are any concerns or issues with this PR let me know! Thanks for the great work with this codebase so far!

## Does this PR introduce a breaking change?
- [x] No

# Links
[Android Notification object documentation](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#androidnotification)
[Cloud Messages with localization example](https://firebase.google.com/docs/cloud-messaging/send-message#example-notification-message-with-localization-options)
