### PR TITLE
Add IOS_FCM_ENABLED variable to allow disabling FCM functionality on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ See [Specifying Android library versions](#specifying-android-library-versions) 
   - `--variable IOS_ENABLE_CRITICAL_ALERTS_ENABLED=true`
   - See [iOS critical notifications](#ios-critical-notifications)
   - Ensure the associated app provisioning profile also has this capability enabled.
+- `IOS_FCM_ENABLED` - allows to completely disable push notifications functionality of the plugin (not just the automatic initialization that is covered by `FIREBASE_FCM_AUTOINIT_ENABLED` variable).
+  - Defaults to `true`, if not specified; i.e. FCM is enabled by default.
+  - This can be handy if you are using this plugin for e.g. Crashlytics and handle push notifications using another plugin. Use `--variable IOS_FCM_ENABLED=false` in this case.
 
 ## Supported Cordova Versions
 - cordova: `>= 10`

--- a/plugin.xml
+++ b/plugin.xml
@@ -106,6 +106,7 @@
 		<hook type="before_plugin_uninstall" src="scripts/ios/before_plugin_uninstall.js" />
 
 		<preference name="IOS_USE_PRECOMPILED_FIRESTORE_POD" default="false" />
+		<preference name="IOS_FCM_ENABLED" default="true" />
 
 		<js-module name="FirebasePlugin" src="www/firebase.js">
 			<clobbers target="FirebasePlugin" />

--- a/scripts/ios/helper.js
+++ b/scripts/ios/helper.js
@@ -271,6 +271,16 @@ end
             appPlistModified = true;
         }
 
+        if(pluginVariables['IOS_FCM_ENABLED'] === 'false'){
+            // Use GoogleService-Info.plist to pass this to the native part reducing noise in Info.plist.
+            // A prefix should make it more clear that this is not the variable of the SDK.
+            googlePlist["FIREBASEX_IOS_FCM_ENABLED"] = false;
+            googlePlistModified = true;
+            // FCM auto-init must be disabled early via the Info.plist in this case.
+            appPlist["FirebaseMessagingAutoInitEnabled"] = false;
+            appPlistModified = true;
+        }
+
         if(googlePlistModified) fs.writeFileSync(path.resolve(iosPlatform.dest), plist.build(googlePlist));
         if(appPlistModified) fs.writeFileSync(path.resolve(iosPlatform.appPlist), plist.build(appPlist));
         if(entitlementsPlistsModified){

--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -17,7 +17,6 @@
 @implementation AppDelegate (FirebasePlugin)
 
 static AppDelegate* instance;
-static id <UNUserNotificationCenterDelegate> _previousDelegate;
 
 + (AppDelegate*) instance {
     return instance;
@@ -26,6 +25,7 @@ static id <UNUserNotificationCenterDelegate> _previousDelegate;
 static NSDictionary* mutableUserInfo;
 static FIRAuthStateDidChangeListenerHandle authStateChangeListener;
 static bool authStateChangeListenerInitialized = false;
+static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterDelegate = nil;
 
 + (void)load {
     Method original = class_getInstanceMethod(self, @selector(application:didFinishLaunchingWithOptions:));
@@ -72,19 +72,22 @@ static bool authStateChangeListenerInitialized = false;
             // Assume that another call (probably from another plugin) did so with the plist
             isFirebaseInitializedWithPlist = true;
         }
-    
-        // Set UNUserNotificationCenter delegate
-        if ([UNUserNotificationCenter currentNotificationCenter].delegate != nil) {
-            _previousDelegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
-        }
-        [UNUserNotificationCenter currentNotificationCenter].delegate = self;
 
-        // Set FCM messaging delegate
-        [FIRMessaging messaging].delegate = self;
-        
+        if (self.isFCMEnabled) {
+            // Setting the delegate even if FCM is disabled would cause conflicts with other plugins dealing
+            // with push notifications (e.g. `urbanairship-cordova`).
+            _prevUserNotificationCenterDelegate = [UNUserNotificationCenter currentNotificationCenter].delegate;
+            [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+            
+            // Set FCM messaging delegate
+            [FIRMessaging messaging].delegate = self;
+        } else {
+            // This property is persistent thus ensuring it stays in sync with FCM settings in newer versions of the app.
+            [[FIRMessaging messaging] setAutoInitEnabled:NO];
+        }
+    
         // Setup Firestore
         [FirebasePlugin setFirestore:[FIRFirestore firestore]];
-        
         
         authStateChangeListener = [[FIRAuth auth] addAuthStateDidChangeListener:^(FIRAuth * _Nonnull auth, FIRUser * _Nullable user) {
             @try {
@@ -98,7 +101,6 @@ static bool authStateChangeListenerInitialized = false;
             }
         }];
 
-
         self.applicationInBackground = @(YES);
         
     }@catch (NSException *exception) {
@@ -106,6 +108,10 @@ static bool authStateChangeListenerInitialized = false;
     }
 
     return YES;
+}
+
+- (BOOL)isFCMEnabled {
+    return FirebasePlugin.firebasePlugin.isFCMEnabled;
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
@@ -130,6 +136,9 @@ static bool authStateChangeListenerInitialized = false;
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    if (!self.isFCMEnabled) {
+        return;
+    }
     [FIRMessaging messaging].APNSToken = deviceToken;
     [FirebasePlugin.firebasePlugin _logMessage:[NSString stringWithFormat:@"didRegisterForRemoteNotificationsWithDeviceToken: %@", deviceToken]];
     [FirebasePlugin.firebasePlugin sendApnsToken:[FirebasePlugin.firebasePlugin hexadecimalStringFromData:deviceToken]];
@@ -138,7 +147,11 @@ static bool authStateChangeListenerInitialized = false;
 //Tells the app that a remote notification arrived that indicates there is data to be fetched.
 // Called when a message arrives in the foreground and remote notifications permission has been granted
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo
-fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+
+    if (!self.isFCMEnabled) {
+        return;
+    }
     
     @try{
         [[FIRMessaging messaging] appDidReceiveMessage:userInfo];
@@ -290,6 +303,9 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    if (!self.isFCMEnabled) {
+        return;
+    }
     [FirebasePlugin.firebasePlugin _logError:[NSString stringWithFormat:@"didFailToRegisterForRemoteNotificationsWithError: %@", error.description]];
 }
 
@@ -311,12 +327,14 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     
     @try{
 
-        if (![notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]){
-            if (_previousDelegate) {
+        if (![notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]) {
+            if (_prevUserNotificationCenterDelegate) {
                 // bubbling notification
-                [_previousDelegate userNotificationCenter:center
-                          willPresentNotification:notification
-                            withCompletionHandler:completionHandler];
+                [_prevUserNotificationCenterDelegate
+                    userNotificationCenter:center
+                    willPresentNotification:notification
+                    withCompletionHandler:completionHandler
+                ];
                 return;
             } else {
                 [FirebasePlugin.firebasePlugin _logError:@"willPresentNotification: aborting as not a supported UNNotificationTrigger"];
@@ -387,12 +405,14 @@ fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
 {
     @try{
         
-        if (![response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![response.notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]){
-            if (_previousDelegate) {
+        if (![response.notification.request.trigger isKindOfClass:UNPushNotificationTrigger.class] && ![response.notification.request.trigger isKindOfClass:UNTimeIntervalNotificationTrigger.class]) {
+            if (_prevUserNotificationCenterDelegate) {
                 // bubbling event
-                [_previousDelegate userNotificationCenter:center
-                               didReceiveNotificationResponse:response
-                            withCompletionHandler:completionHandler];
+                [_prevUserNotificationCenterDelegate
+                	userNotificationCenter:center
+                	didReceiveNotificationResponse:response
+                	withCompletionHandler:completionHandler
+                ];
                 return;
             } else {
                 [FirebasePlugin.firebasePlugin _logMessage:@"didReceiveNotificationResponse: aborting as not a supported UNNotificationTrigger"];

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -140,6 +140,8 @@
 - (void)deleteChannel:(CDVInvokedUrlCommand *)command;
 - (void)listChannels:(CDVInvokedUrlCommand *)command;
 
+@property (nonatomic, readonly) BOOL isFCMEnabled;
+
 @property (nonatomic, copy) NSString *notificationCallbackId;
 @property (nonatomic, copy) NSString *openSettingsCallbackId;
 @property (nonatomic, copy) NSString *tokenRefreshCallbackId;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [x] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?

There is a conflict on iOS in case push notifications are handled by another plugin (Airship), i.e. when FCM functionality of the plugin is not used. Even with `FIREBASE_FCM_AUTOINIT_ENABLED` set to `false` the plugin still would set its delegate for `UNUserNotificationCenter` however preventing regular flow of notifications. This PR is allows to disable FCM on iOS via `IOS_FCM_ENABLED` variable.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?

Checked in an [isolated example](https://github.com/MediaMonksMobile/FirebaseAirshipConflictExample) and used in a production app.

## What testing has been done on existing functionality?

## Other information
