### PR TITLE
(ios) Fix foreground notifications not being displayed after calling grantPermission when permissions haven't been previously granted

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -322,6 +322,7 @@ static FIRMultiFactorResolver* multiFactorResolver;
                         @try {
                             NSLog(@"requestAuthorizationWithOptions: granted=%@", granted ? @"YES" : @"NO");
                             if (error == nil && granted) {
+                                [UNUserNotificationCenter currentNotificationCenter].delegate = AppDelegate.instance;
                                 [self registerForRemoteNotifications];
                             }
                             [self handleBoolResultWithPotentialError:error command:command result:granted];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->
Currently, calling `grantPermission` on ios while permissions have not been granted will cause received foreground notifications (notifications with `"notification_foreground": "true"`) to not be displayed until app is restarted. This seems to happen because the `grantPermission` function changes the notification center delegate if called and permissions have not been already granted:
https://github.com/dpa99c/cordova-plugin-firebasex/blob/ab660596f311fd9cb8fa70e0b1de9bb60ace25d6/src/ios/FirebasePlugin.m#L303-L310

Meanwhile the completionHandler for the permission request never sets this back to the original value
https://github.com/dpa99c/cordova-plugin-firebasex/blob/ab660596f311fd9cb8fa70e0b1de9bb60ace25d6/src/ios/FirebasePlugin.m#L321-L331

The notification center delegate is first set here during app startup:
https://github.com/dpa99c/cordova-plugin-firebasex/blob/ab660596f311fd9cb8fa70e0b1de9bb60ace25d6/src/ios/AppDelegate%2BFirebasePlugin.m#L80

The fix included in this PR simply sets the notification center delegate back to the AppDelegate if permissions were granted successfully.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->
This change has been tested in a production app

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information
