### PR TITLE
fix(ios): Update helper.js to build on Xcode 16.0

### DIFF
--- a/scripts/ios/helper.js
+++ b/scripts/ios/helper.js
@@ -229,7 +229,7 @@ module.exports = {
             DEBUG_INFORMATION_FORMAT = pluginVariables['IOS_STRIP_DEBUG'] && pluginVariables['IOS_STRIP_DEBUG'] === 'true' ? 'dwarf' : 'dwarf-with-dsym',
             IPHONEOS_DEPLOYMENT_TARGET = podFile.match(iosDeploymentTargetPodRegEx)[1];
 
-        if(!podFile.match('post_install')){
+        if (!podFile.match('post_install')) {
             podFile += `
 post_install do |installer|
     installer.pods_project.targets.each do |target|
@@ -238,6 +238,15 @@ post_install do |installer|
             config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '${IPHONEOS_DEPLOYMENT_TARGET}'
             if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
                 config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+            end
+        end
+        if target.name == 'BoringSSL-GRPC'
+            target.source_build_phase.files.each do |file|
+                if file.settings && file.settings['COMPILER_FLAGS']
+                    flags = file.settings['COMPILER_FLAGS'].split
+                    flags.reject! { |flag| flag == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }
+                    file.settings['COMPILER_FLAGS'] = flags.join(' ')
+                end
             end
         end
     end


### PR DESCRIPTION
fix BoringSSL-GRPC build issue

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
impossible to build pods on iOS with Xcode 16.0. Build issue BoringSSL-GRPC
integrate workaround from 
https://stackoverflow.com/questions/78608693/boringssl-grpc-unsupported-option-g-for-target-arm64-apple-ios15-0/78633109#78633109
issue : https://github.com/dpa99c/cordova-plugin-firebasex/issues/892

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
build on Xcode 16.0
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information
