### PR TITLE
feat(ios): prepare for cordova-ios 8 support - corrected app name

### DIFF
--- a/scripts/lib/utilities.js
+++ b/scripts/lib/utilities.js
@@ -64,6 +64,14 @@ Utilities.writeJsonToXmlFile = function(jsonObj, filepath, parseOpts){
  * Used to get the name of the application as defined in the config.xml.
  */
 Utilities.getAppName = function(){
+    // Cordova-iOS 8 and greater has a static app name of "App".
+    // Check for "App.xcodeproj" and return "App" if it exists.
+    const xcodeprojPath = path.resolve('platforms', 'ios', 'App.xcodeproj');
+    if(fs.existsSync(xcodeprojPath)) {
+        return 'App';
+    }
+
+    // If not "App", try and extract from "config.xml" as before for older Cordova-iOS platforms.
     return Utilities.parseConfigXml().widget.name._text.toString().trim();
 };
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

Prepare for Cordova-iOS 8 support.

Next major release will have a static app name of "App".

This PR will check for "App" first and return the app name as "App", when it exists, or fall back to original behavior.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

Tested against `cordova-ios@nightly` 8.0, which will later be released as `8.0.0-beta.1`

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information
