### PR TITLE
Removed unnecessary "rawNonce" from FirebasePlugin.m

### DIFF
--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -1049,7 +1049,6 @@ static NSMutableArray* pendingGlobalJS = nil;
                       [result setValue:@"true" forKey:@"instantVerification"];
                       [result setValue:key forKey:@"id"];
                       [result setValue:idToken forKey:@"idToken"];
-                      [result setValue:rawNonce forKey:@"rawNonce"];
                       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
                   } else {
                       pluginResult = [self createAuthErrorResult:error];


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
<!-- Describe any current behavior that you are modifying, or link to a relevant issue. -->
<!-- Describe the new behaviour added/modified and its purpose. -->

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?
<!-- e.g. if an example project exists for this plugin, has it been updated to test the new functionality? -->

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information

I had this pull request opened 6 months ago (https://github.com/dpa99c/cordova-plugin-firebasex/pull/883) and unfortunately you merged a few days ago just when I was messing around with "rawNonce" on the Google Authentication for iOS, to test a few things. 

You need this change, which basically reverts my pull request to the original state, otherwise the app crashes. The rawNonce is only used when logging in with Apple, as per the original pull request.
