### PR TITLE
Handle notification callback in the background

### DIFF
--- a/src/ios/AppDelegate+FirebasePlugin.m
+++ b/src/ios/AppDelegate+FirebasePlugin.m
@@ -156,6 +156,8 @@ static __weak id <UNUserNotificationCenterDelegate> _prevUserNotificationCenterD
     }@catch (NSException *exception) {
         [FirebasePlugin.firebasePlugin handlePluginExceptionWithoutContext:exception];
     }
+    
+    [FirebasePlugin.firebasePlugin sendPendingNotifications];
 }
 
 - (void)applicationDidEnterBackground:(UIApplication *)application {

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -7,6 +7,7 @@
 
 - (void)setAutoInitEnabled:(CDVInvokedUrlCommand*)command;
 - (void)isAutoInitEnabled:(CDVInvokedUrlCommand*)command;
+- (void)sendPendingNotifications;
 
 // Authentication
 - (void)verifyPhoneNumber:(CDVInvokedUrlCommand*)command;


### PR DESCRIPTION
## PR Type
New feature - Hold notifications when the app is in background and and call the app callback once back in foreground.

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [x] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [x] Exhaustive testing has been carried out for the new functionality
- [x] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?
New message notifications, call the onMessageReceived callback. This might be important to handle new notifications by the app, especially data notifications. In both Android and iOS, the plugin is calling the onMessageReceived callback but when the application is in the background for more than 20-30 seconds, the callback does not execute.
In case of Android, when the app is not active (the main activity is closed), the callback is not valid as the WebView does not exist.

The plugin already implements a queue to hold any pending notifications until the app calls onMessageReceived for the first time or the plugin has finished initializing.
This PR extends the functionality of this queue to hold any pending notifications when the app is in the background or inactive. As soon as the application resumes, the plugin will send all pending notifications back to the onMessageReceived callback.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

The default behavior of the plugin when sending notifications to the onMessageReceived callback when the app is in the background is not consistent and depends on the device type and the amount of time the application is in the background. The new behavior must be documented and properly explained.
In case some applications rely on notifications being sent while the app is in the background, this change might break this behavior as notifications will never be calling onMessageReceived callback when the app is in the background.
There should be minimal or no impact on visible notifications.

## What testing has been done on the changes in the PR?
Multiple Android and iOS devices tested in all states for processing data notifications.

## What testing has been done on existing functionality?
Other notification types seem to not being impacted. No other functionality of the plugin has been changed.

## Other information
Bringing this PR to the public discussion to understand if this is something that should be integrated in the plugin. If this is something valuable or could break the existing behavior or something we couldn't think about.
 