### PR TITLE
remove unused cordova-ios import that breaks projects without ios platform

### DIFF
--- a/scripts/lib/utilities.js
+++ b/scripts/lib/utilities.js
@@ -4,7 +4,6 @@
 var fs = require('fs');
 var path = require("path");
 var parser = require('xml-js');
-const cordova_ios = require("cordova-ios");
 
 var _configXml, _pluginXml, _context, _pluginVariables;
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

## What is the purpose of this PR?
In the latest version trying to build a project that has no cordova-ios platform failed with the following error:

Error: Cannot find module 'cordova-ios'
Require stack:
- project\src-cordova\plugins\cordova-plugin-firebasex\scripts\lib\utilities.js
- project\src-cordova\plugins\cordova-plugin-firebasex\scripts\after_prepare.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\hooks\HooksRunner.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\install.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\src\plugman\plugman.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\node_modules\cordova-lib\cordova-lib.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\src\help.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\src\cli.js
- C:\Users\sarantis\AppData\Roaming\npm\node_modules\cordova\bin\cordova

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## What testing has been done on the changes in the PR?
We tested the fix with our project that failed the build state because of the require.

## What testing has been done on existing functionality?
this PR does not change functionality

