### PR TITLE
use onMessage to get the ready state

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -276,15 +276,21 @@ public class FirebasePlugin extends CordovaPlugin {
                     defaultChannelId = getStringResource("default_notification_channel_id");
                     defaultChannelName = getStringResource("default_notification_channel_name");
                     createDefaultChannel();
-
-                    pluginInitialized = true;
-                    executePendingGlobalJavascript();
+                    pluginInitialized = true;                   
 
                 } catch (Exception e) {
                     handleExceptionWithoutContext(e);
                 }
             }
         });
+    }
+
+    @Override
+    public Object onMessage(String id, Object data){
+        if(id === "onPageFinished"){
+            Log.d(TAG, "Page ready init javascript");
+            executePendingGlobalJavascript();
+        }
     }
 
     @Override


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [X ] Bugfix

## What is the purpose of this PR?
Wait for onMessage with id "onPageFinished" to run javascript as per suggestion in
https://github.com/apache/cordova-android/issues/1715#issuecomment-3020381378

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of JavaScript execution timing to ensure actions occur after the page has finished loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->