### PR TITLE
Wait for js interface

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -287,7 +287,7 @@ public class FirebasePlugin extends CordovaPlugin {
 
     @Override
     public Object onMessage(String id, Object data){
-        if(id === "onPageFinished"){
+        if("onPageFinished".equals(id)){       
             Log.d(TAG, "Page ready init javascript");
             executePendingGlobalJavascript();
         }

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -287,15 +287,15 @@ public class FirebasePlugin extends CordovaPlugin {
 
     @Override
     public Object onMessage(String id, Object data){
-    +    if (id == null) {
-    +        return super.onMessage(id, data);
-    +    }
+        if (id == null) {
+            return super.onMessage(id, data);
+        }
         if("onPageFinished".equals(id)){       
             Log.d(TAG, "Page ready init javascript");
             executePendingGlobalJavascript();
-    +       return null;
+            return null;
         }
-    +    return super.onMessage(id, data);
+        return super.onMessage(id, data);
     }
 
     @Override

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -276,15 +276,21 @@ public class FirebasePlugin extends CordovaPlugin {
                     defaultChannelId = getStringResource("default_notification_channel_id");
                     defaultChannelName = getStringResource("default_notification_channel_name");
                     createDefaultChannel();
-
-                    pluginInitialized = true;
-                    executePendingGlobalJavascript();
+                    pluginInitialized = true;                   
 
                 } catch (Exception e) {
                     handleExceptionWithoutContext(e);
                 }
             }
         });
+    }
+
+    @Override
+    public Object onMessage(String id, Object data){
+        if(id === "onPageFinished"){
+            Log.d(TAG, "Page ready init javascript");
+            executePendingGlobalJavascript();
+        }
     }
 
     @Override

--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -287,10 +287,15 @@ public class FirebasePlugin extends CordovaPlugin {
 
     @Override
     public Object onMessage(String id, Object data){
+    +    if (id == null) {
+    +        return super.onMessage(id, data);
+    +    }
         if("onPageFinished".equals(id)){       
             Log.d(TAG, "Page ready init javascript");
             executePendingGlobalJavascript();
+    +       return null;
         }
+    +    return super.onMessage(id, data);
     }
 
     @Override


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- [ X ] Bugfix

## What is the purpose of this PR?
use onMessage with id "onPageFinished" to run JS as suggested in https://github.com/apache/cordova-android/issues/1715#issuecomment-3036189983

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X ] No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of pending JavaScript execution, which now occurs after the page has fully loaded instead of during plugin initialization. This ensures smoother and more reliable plugin behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->