### PR TITLE
(android) fix: plugin no longer gets stuck during startup on some devices; correct wait for JS interface, and use evaluateJavascript

### DIFF
--- a/src/android/FirebasePlugin.java
+++ b/src/android/FirebasePlugin.java
@@ -152,6 +152,7 @@ public class FirebasePlugin extends CordovaPlugin {
     protected static Context applicationContext = null;
     private static Activity cordovaActivity = null;
     private static boolean pluginInitialized = false;
+    private static boolean onPageFinished = false;
     private static ArrayList<String> pendingGlobalJS = null;
 
     protected static final String TAG = "FirebasePlugin";
@@ -292,6 +293,7 @@ public class FirebasePlugin extends CordovaPlugin {
         }
         if("onPageFinished".equals(id)){       
             Log.d(TAG, "Page ready init javascript");
+            onPageFinished = true;
             executePendingGlobalJavascript();
             return null;
         }
@@ -3812,7 +3814,7 @@ public class FirebasePlugin extends CordovaPlugin {
     }
 
     private void executeGlobalJavascript(final String jsString) {
-        if(pluginInitialized){
+        if(pluginInitialized && onPageFinished){
             doExecuteGlobalJavascript(jsString);
         } else {
             if(pendingGlobalJS == null) {
@@ -3839,7 +3841,7 @@ public class FirebasePlugin extends CordovaPlugin {
         cordovaActivity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                webView.loadUrl("javascript:" + jsString);
+                webView.getEngine().evaluateJavascript(jsString, null);
             }
         });
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
Please check your PR fulfills the following requirements:

Bugfixes:
- [ ] Regression testing has been carried out using the [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) to ensure the intended bug is fixed and no regression bugs have been inadvertently introduced.

New features/enhancements:
- [ ] Exhaustive testing has been carried out for the new functionality
- [ ] Regression testing has been carried out to ensure no existing functionality is adversely affected
- [ ] Documentation has been added / updated
- [ ] The [example project](https://github.com/dpa99c/cordova-plugin-firebasex-test) has been update to validate/demonstrate the new functionality.

## What is the purpose of this PR?

This pull request contains 2 bug fixes spread across 2 commits..

- (android) fix: plugin no longer gets stuck during startup on some devices; correct wait for JS interface, and use evaluateJavascript 0c0ac07359274b51444e39d500f95e334947613a

The first of these fixes a problem that on some devices caused the app/plugin to be stuck during startup (or only open after several minutes), likely because JavaScript code was being executed before the WebView was fully loaded. This commit fixes the issue by properly waiting for `onPageFinished` (Improving #942 changes) and replaces `loadUrl` with `evaluateJavascript` to improve performance (`evaluateJavascript` is available from SDK 19+, so this shouldn't be an issue).

- (android) fix: add retry mechanism for idTokenListener 987145ccc8d24f4fbd1bb68cdad8597d2e63ce20

This attempts to fix the fatal exception reported in #925. I added a check to see if `FirebasePlugin.instance` is null and retry up to 10 more times with 50ms delays. If it's still null after that, it returns.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing plugin versions. -->

## What testing has been done on the changes in the PR?

- (android) fix: plugin no longer gets stuck during startup on some devices; correct wait for JS interface, and use evaluateJavascript 0c0ac07359274b51444e39d500f95e334947613a

I tested it on one of the affected devices, and the app is no longer stuck during startup.

- (android) fix: add retry mechanism for idTokenListener 987145ccc8d24f4fbd1bb68cdad8597d2e63ce20

I tested it on the same device and on an Android emulator, the app opens fine. I haven't been able to test `FirebaseAuth` since I don't use it, but, for example, notifications are still working correctly.

## What testing has been done on existing functionality?
<!-- e.g. if an example project exists for this plugin, has been it been tested to ensure no regression bugs have been introduced? -->

## Other information


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Fixed intermittent initialization issues on Android that could prevent Firebase features from working on first launch.
  * Ensured in-app scripts run only after the web view is ready, reducing race-condition errors.
  * Prevented missed ID token refresh events during startup.

* Stability
  * Added smarter retry and queuing to improve startup reliability and reduce error logs.
  * Improved JavaScript execution path for smoother, more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->